### PR TITLE
Change expected configuration file naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-private-key.pem
 release.zip
 node_modules
 npm-debug.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "command": "yarn start",
+            "name": "Start app",
+            "request": "launch",
+            "type": "node-terminal",
+            "preLaunchTask": "yarn: build"
+        },
+        {
             "name": "Debug Jest Tests",
             "type": "node",
             "request": "launch",

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,7 +38,7 @@ const processPushEvent =
       app.log.debug(`Saw files changed in ${payload.after}:`)
       app.log.debug(filesChanged)
 
-      const configFileName = `${payload.repository.name}.yaml`
+      const configFileName = `${payload.repository.name}-templates.yaml`
 
       if (filesChanged.includes(configFileName)) {
         const parsed = await determineConfigurationChanges(app, context)(configFileName, repository, payload.after)

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,11 +38,11 @@ const processPushEvent =
       app.log.debug(`Saw files changed in ${payload.after}:`)
       app.log.debug(filesChanged)
 
-      const configFileName = `${payload.repository.name}-templates.yaml`
+      const configFileName = `.pleo/templates.yaml`
 
       if (filesChanged.includes(configFileName)) {
         const parsed = await determineConfigurationChanges(app, context)(configFileName, repository, payload.after)
-        const { version, templates: processed } = await renderTemplates(app, context)(repository, parsed)
+        const { version, templates: processed } = await renderTemplates(app, context)(parsed)
         const pullRequestNumber = await commitFiles(app, context)(repository, version, processed)
         app.log.info(`Committed templates to '${repository.owner}/${repository.repo}' in #${pullRequestNumber}`)
         app.log.info(`See: https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}`)
@@ -53,8 +53,14 @@ const processPushEvent =
     }
   }
 
-export = (app: Probot) => {
+export = async (app: Probot) => {
   config()
+
+  const authenticated = await (await app.auth(Number(process.env.APP_ID))).apps.listInstallations()
+  if (!authenticated) {
+    app.log.error('The application is not installed with expected authentication. Exiting.')
+  }
+
   const branchesToProcess = findBranchesToProcess(app)
   app.on('push', async (context: Context<'push'>) => {
     await processPushEvent(branchesToProcess)(context.payload as PushEvent, context, app)

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,7 +38,7 @@ const processPushEvent =
       app.log.debug(`Saw files changed in ${payload.after}:`)
       app.log.debug(filesChanged)
 
-      const configFileName = `.pleo/templates.yaml`
+      const configFileName = `.config/templates.yaml`
 
       if (filesChanged.includes(configFileName)) {
         const parsed = await determineConfigurationChanges(app, context)(configFileName, repository, payload.after)

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface Templates {
 }
 
 export interface TemplateInformation {
-  path: string
+  contents: ArrayBuffer
   version: string
 }
 


### PR DESCRIPTION
This renames the expected repository YAML configuration naming from `<repository-name>.yaml` to `.config/templates.yaml` to make it clearer for teams what the file contents are expected to be. 

This also resolves a duplicate PR creation bug and avoid storing any files to disk when extracting templates.