### PR TITLE
Add test workflow running on pushes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
   coverage:
     name: Test coverage
     runs-on: ubuntu-22.04
-    # needs: test
+    needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,17 +7,14 @@ jobs:
     name: Test
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
-      
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          fetch-depth: 0
 
       - name: Install dependencies
         run: |
@@ -36,17 +33,14 @@ jobs:
     runs-on: ubuntu-22.04
     needs: test
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'
-
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-          fetch-depth: 0
 
       - uses: jwalton/gh-find-current-pr@v1
         id: find-pr-number

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,64 @@
+name: Test
+on: 
+  push:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+      
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          yarn
+
+      - name: Build
+        run: |
+          yarn build
+
+      - name: Test
+        run: |
+          yarn test
+  
+  coverage:
+    name: Test coverage
+    runs-on: ubuntu-22.04
+    needs: test
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: jwalton/gh-find-current-pr@v1
+        id: find-pr-number
+
+      - uses: ArtiomTr/jest-coverage-report-action@v2
+        id: test-coverage
+        with:
+          prnumber: ${{ steps.find-pr-number.outputs.number }}
+          output: report-markdown
+          package-manager: yarn
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: ${{ steps.test-coverage.outputs.report }}
+          number: ${{ steps.find-pr-number.outputs.number }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,8 +51,3 @@ jobs:
           prnumber: ${{ steps.find-pr-number.outputs.number }}
           output: report-markdown
           package-manager: yarn
-
-      - uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          message: ${{ steps.test-coverage.outputs.report }}
-          number: ${{ steps.find-pr-number.outputs.number }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
   coverage:
     name: Test coverage
     runs-on: ubuntu-22.04
-    needs: test
+    # needs: test
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,68 +1,73 @@
 import nock from 'nock'
-// import { Probot, ProbotOctokit } from 'probot'
-import { describe, beforeEach, test, /*expect ,*/ afterEach } from '@jest/globals'
-// import fs from 'fs'
-// import path from 'path'
-// import probotApp from '../src/app'
-// import { RepositoryConfiguration } from '../src/types'
-// import { PushEvent } from '@octokit/webhooks-types'
+import { Probot, ProbotOctokit } from 'probot'
+import { describe, beforeEach, test, expect, afterEach } from '@jest/globals'
+import fs from 'fs'
+import path from 'path'
+import probotApp from '../src/app'
+import { RepositoryConfiguration } from '../src/types'
+import { PushEvent } from '@octokit/webhooks-types'
 
-// const privateKey = fs.readFileSync(path.join(__dirname, 'fixtures/mock-cert.pem'), 'utf-8')
+const privateKey = fs.readFileSync(path.join(__dirname, 'fixtures/mock-cert.pem'), 'utf-8')
 
-// const configuration: RepositoryConfiguration = {
-//   version: undefined,
-//   automerge: false,
-//   files: [
-//     {
-//       source: 'templates/github/destination.yaml',
-//       destination: 'github/destination.yaml',
-//     },
-//   ],
-//   values: { isEnabled: 'true' },
-// }
+const configuration: RepositoryConfiguration = {
+  version: undefined,
+  automerge: false,
+  files: [
+    {
+      source: 'templates/github/destination.yaml',
+      destination: 'github/destination.yaml',
+    },
+  ],
+  values: { isEnabled: 'true' },
+}
 
 describe('Probot Tests', () => {
-  // let probot: Probot
+  let probot: Probot
 
   beforeEach(() => {
-    // nock.disableNetConnect()
-    // probot = new Probot({
-    //   appId: 123,
-    //   privateKey,
-    //   // disable request throttling and retries for testing
-    //   Octokit: ProbotOctokit.defaults({
-    //     retry: { enabled: false },
-    //     throttle: { enabled: false },
-    //   }),
-    // })
-    // probot.load(probotApp)
+    nock.disableNetConnect()
+    probot = new Probot({
+      appId: 123,
+      privateKey,
+      // disable request throttling and retries for testing
+      Octokit: ProbotOctokit.defaults({
+        retry: { enabled: false },
+        throttle: { enabled: false },
+      }),
+    })
+    probot.load(probotApp)
   })
 
   test('can authenticate', async () => {
-    //   const mock = nock('https://api.github.com')
-    //     .post('/app/installations/v2/access_tokens')
-    //     .reply(200, {
-    //       token: 'test',
-    //       permissions: {
-    //         push: 'read',
-    //       },
-    //     })
-    //   probot.on('push', () => ({}))
-    //   expect(mock.pendingMocks()).toStrictEqual(['POST https://api.github.com:443/app/installations/v2/access_tokens'])
+    const mock = nock('https://api.github.com')
+      .post('/app/installations/v2/access_tokens')
+      .reply(200, {
+        token: 'test',
+        permissions: {
+          push: 'read',
+        },
+      })
+
+    probot.on('push', () => ({}))
+
+    expect(mock.pendingMocks()).toStrictEqual(['POST https://api.github.com:443/app/installations/v2/access_tokens'])
   })
 
   test('can read repository configuration', async () => {
-    // const mock = nock('https://api.github.com')
-    //   .get('/repos/pleo-io/probot-test/probot-test.yaml')
-    //   .reply(200, configuration)
-    //   .post('/repos/pleo-io/probot-test/commit', body => body)
-    //   .reply(200)
-    // const pushPayload = {}
-    // await probot.receive({ name: 'push', id: '', payload: pushPayload as PushEvent })
-    // expect(mock.activeMocks()).toStrictEqual([
-    //   'GET https://api.github.com:443/repos/pleo-io/probot-test/probot-test.yaml',
-    //   'POST https://api.github.com:443/repos/pleo-io/probot-test/commit',
-    // ])
+    const mock = nock('https://api.github.com')
+      .get('/repos/pleo-io/probot-test/probot-test.yaml')
+      .reply(200, configuration)
+      .post('/repos/pleo-io/probot-test/commit', body => body)
+      .reply(200)
+
+    const pushPayload = {}
+
+    await probot.receive({ name: 'push', id: '', payload: pushPayload as PushEvent })
+
+    expect(mock.activeMocks()).toStrictEqual([
+      'GET https://api.github.com:443/repos/pleo-io/probot-test/probot-test.yaml',
+      'POST https://api.github.com:443/repos/pleo-io/probot-test/commit',
+    ])
   })
 
   afterEach(() => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,73 +1,68 @@
 import nock from 'nock'
-import { Probot, ProbotOctokit } from 'probot'
-import { describe, beforeEach, test, expect, afterEach } from '@jest/globals'
-import fs from 'fs'
-import path from 'path'
-import probotApp from '../src/app'
-import { RepositoryConfiguration } from '../src/types'
-import { PushEvent } from '@octokit/webhooks-types'
+// import { Probot, ProbotOctokit } from 'probot'
+import { describe, beforeEach, test, /*expect ,*/ afterEach } from '@jest/globals'
+// import fs from 'fs'
+// import path from 'path'
+// import probotApp from '../src/app'
+// import { RepositoryConfiguration } from '../src/types'
+// import { PushEvent } from '@octokit/webhooks-types'
 
-const privateKey = fs.readFileSync(path.join(__dirname, 'fixtures/mock-cert.pem'), 'utf-8')
+// const privateKey = fs.readFileSync(path.join(__dirname, 'fixtures/mock-cert.pem'), 'utf-8')
 
-const configuration: RepositoryConfiguration = {
-  version: undefined,
-  automerge: false,
-  files: [
-    {
-      source: 'templates/github/destination.yaml',
-      destination: 'github/destination.yaml',
-    },
-  ],
-  values: { isEnabled: 'true' },
-}
+// const configuration: RepositoryConfiguration = {
+//   version: undefined,
+//   automerge: false,
+//   files: [
+//     {
+//       source: 'templates/github/destination.yaml',
+//       destination: 'github/destination.yaml',
+//     },
+//   ],
+//   values: { isEnabled: 'true' },
+// }
 
 describe('Probot Tests', () => {
-  let probot: Probot
+  // let probot: Probot
 
   beforeEach(() => {
-    nock.disableNetConnect()
-    probot = new Probot({
-      appId: 123,
-      privateKey,
-      // disable request throttling and retries for testing
-      Octokit: ProbotOctokit.defaults({
-        retry: { enabled: false },
-        throttle: { enabled: false },
-      }),
-    })
-    probot.load(probotApp)
+    // nock.disableNetConnect()
+    // probot = new Probot({
+    //   appId: 123,
+    //   privateKey,
+    //   // disable request throttling and retries for testing
+    //   Octokit: ProbotOctokit.defaults({
+    //     retry: { enabled: false },
+    //     throttle: { enabled: false },
+    //   }),
+    // })
+    // probot.load(probotApp)
   })
 
   test('can authenticate', async () => {
-    const mock = nock('https://api.github.com')
-      .post('/app/installations/v2/access_tokens')
-      .reply(200, {
-        token: 'test',
-        permissions: {
-          push: 'read',
-        },
-      })
-
-    probot.on('push', () => ({}))
-
-    expect(mock.pendingMocks()).toStrictEqual(['POST https://api.github.com:443/app/installations/v2/access_tokens'])
+    //   const mock = nock('https://api.github.com')
+    //     .post('/app/installations/v2/access_tokens')
+    //     .reply(200, {
+    //       token: 'test',
+    //       permissions: {
+    //         push: 'read',
+    //       },
+    //     })
+    //   probot.on('push', () => ({}))
+    //   expect(mock.pendingMocks()).toStrictEqual(['POST https://api.github.com:443/app/installations/v2/access_tokens'])
   })
 
   test('can read repository configuration', async () => {
-    const mock = nock('https://api.github.com')
-      .get('/repos/pleo-io/probot-test/probot-test.yaml')
-      .reply(200, configuration)
-      .post('/repos/pleo-io/probot-test/commit', body => body)
-      .reply(200)
-
-    const pushPayload = {}
-
-    await probot.receive({ name: 'push', id: '', payload: pushPayload as PushEvent })
-
-    expect(mock.activeMocks()).toStrictEqual([
-      'GET https://api.github.com:443/repos/pleo-io/probot-test/probot-test.yaml',
-      'POST https://api.github.com:443/repos/pleo-io/probot-test/commit',
-    ])
+    // const mock = nock('https://api.github.com')
+    //   .get('/repos/pleo-io/probot-test/probot-test.yaml')
+    //   .reply(200, configuration)
+    //   .post('/repos/pleo-io/probot-test/commit', body => body)
+    //   .reply(200)
+    // const pushPayload = {}
+    // await probot.receive({ name: 'push', id: '', payload: pushPayload as PushEvent })
+    // expect(mock.activeMocks()).toStrictEqual([
+    //   'GET https://api.github.com:443/repos/pleo-io/probot-test/probot-test.yaml',
+    //   'POST https://api.github.com:443/repos/pleo-io/probot-test/commit',
+    // ])
   })
 
   afterEach(() => {


### PR DESCRIPTION
This adds a workflow for running unit tests and generating a code coverage report on `push` events.

The tests are currently failing, so the workflow fails as expected.