### PR TITLE
Prefer console.log to Probot.log to avoid passing the app object around globally

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -5,64 +5,63 @@ import determineConfigurationChanges from './configuration'
 import { renderTemplates } from './templates'
 import commitFiles from './git'
 
-const findBranchesToProcess = (app: Probot) => {
+const findBranchesToProcess = () => {
   const branches = process.env.BRANCHES_TO_PROCESS
   if (!branches) {
-    app.log.error('Environment variable BRANCHES_TO_PROCESS is not set.')
+    console.error('Environment variable BRANCHES_TO_PROCESS is not set.')
     throw Error('Environment variable BRANCHES_TO_PROCESS is not set.')
   }
 
   return new RegExp(branches)
 }
 
-const processPushEvent =
-  (branchesToProcess: RegExp) => async (payload: PushEvent, context: Context<'push'>, app: Probot) => {
-    if (!branchesToProcess.test(payload.ref)) return
+const processPushEvent = (branchesToProcess: RegExp) => async (payload: PushEvent, context: Context<'push'>) => {
+  if (!branchesToProcess.test(payload.ref)) return
 
-    app.log(`${context.name} event happened on '${payload.ref}'`)
-    try {
-      const repository = {
-        owner: payload.repository.owner.login,
-        repo: payload.repository.name,
-      }
-      app.log.info(`Processing changes made to ${repository.owner}/${repository.repo} in ${payload.after}.`)
-
-      const commit = await context.octokit.repos.getCommit({
-        ...repository,
-        ref: payload.after,
-      })
-      app.log.debug('Fetched commit:')
-      app.log.debug(commit)
-
-      const filesChanged = commit.data.files?.map(c => c.filename) ?? []
-      app.log.debug(`Saw files changed in ${payload.after}:`)
-      app.log.debug(filesChanged)
-
-      const configFileName = `.config/templates.yaml`
-
-      if (filesChanged.includes(configFileName)) {
-        const parsed = await determineConfigurationChanges(app, context)(configFileName, repository, payload.after)
-        const { version, templates: processed } = await renderTemplates(app, context)(parsed)
-        const pullRequestNumber = await commitFiles(app, context)(repository, version, processed)
-        app.log.info(`Committed templates to '${repository.owner}/${repository.repo}' in #${pullRequestNumber}`)
-        app.log.info(`See: https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}`)
-      }
-    } catch (e: unknown) {
-      app.log.error(`Failed to process commit '${payload.after}' with error:`)
-      app.log.error(e as never)
+  console.log(`${context.name} event happened on '${payload.ref}'`)
+  try {
+    const repository = {
+      owner: payload.repository.owner.login,
+      repo: payload.repository.name,
     }
+    console.info(`Processing changes made to ${repository.owner}/${repository.repo} in ${payload.after}.`)
+
+    const commit = await context.octokit.repos.getCommit({
+      ...repository,
+      ref: payload.after,
+    })
+    console.debug('Fetched commit:')
+    console.debug(commit)
+
+    const filesChanged = commit.data.files?.map(c => c.filename) ?? []
+    console.debug(`Saw files changed in ${payload.after}:`)
+    console.debug(filesChanged)
+
+    const configFileName = `.config/templates.yaml`
+
+    if (filesChanged.includes(configFileName)) {
+      const parsed = await determineConfigurationChanges(context)(configFileName, repository, payload.after)
+      const { version, templates: processed } = await renderTemplates(context)(parsed)
+      const pullRequestNumber = await commitFiles(context)(repository, version, processed)
+      console.info(`Committed templates to '${repository.owner}/${repository.repo}' in #${pullRequestNumber}`)
+      console.info(`See: https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}`)
+    }
+  } catch (e: unknown) {
+    console.error(`Failed to process commit '${payload.after}' with error:`)
+    console.error(e as never)
   }
+}
 
 export = async (app: Probot) => {
   config()
 
   const authenticated = await (await app.auth(Number(process.env.APP_ID))).apps.listInstallations()
   if (!authenticated) {
-    app.log.error('The application is not installed with expected authentication. Exiting.')
+    console.error('The application is not installed with expected authentication. Exiting.')
   }
 
-  const branchesToProcess = findBranchesToProcess(app)
+  const branchesToProcess = findBranchesToProcess()
   app.on('push', async (context: Context<'push'>) => {
-    await processPushEvent(branchesToProcess)(context.payload as PushEvent, context, app)
+    await processPushEvent(branchesToProcess)(context.payload as PushEvent, context)
   })
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,21 +1,20 @@
-import { Context, Probot } from 'probot'
+import { Context } from 'probot'
 import { parse } from 'yaml'
 import { RepositoryDetails, RepositoryConfiguration } from './types'
 
-export default (app: Probot, context: Context<'push'>) =>
-  async (fileName: string, repository: RepositoryDetails, sha: string) => {
-    app.log.debug(`Saw changes to ${fileName}.`)
-    const fileContents = await context.octokit.repos.getContent({
-      ...repository,
-      path: fileName,
-      ref: sha,
-    })
+export default (context: Context<'push'>) => async (fileName: string, repository: RepositoryDetails, sha: string) => {
+  console.debug(`Saw changes to ${fileName}.`)
+  const fileContents = await context.octokit.repos.getContent({
+    ...repository,
+    path: fileName,
+    ref: sha,
+  })
 
-    const { content } = fileContents.data as { content: string }
-    const decodedContent = Buffer.from(content, 'base64').toString()
-    app.log.debug(`'${fileName}' contains:`)
-    app.log.debug(decodedContent)
+  const { content } = fileContents.data as { content: string }
+  const decodedContent = Buffer.from(content, 'base64').toString()
+  console.debug(`'${fileName}' contains:`)
+  console.debug(decodedContent)
 
-    const parsed: RepositoryConfiguration = parse(decodedContent)
-    return parsed
-  }
+  const parsed: RepositoryConfiguration = parse(decodedContent)
+  return parsed
+}

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,4 @@
-import { Context, Probot } from 'probot'
+import { Context } from 'probot'
 import { PRDetails, RepositoryDetails, Template } from './types'
 
 const baseBranchName = 'centralized-templates'
@@ -6,29 +6,27 @@ const reducedBranchName = `heads/${baseBranchName}`
 const fullBranchName = `refs/${reducedBranchName}`
 
 const getOrCreateNewBranch =
-  (app: Probot, context: Context<'push'>) => async (repository: RepositoryDetails, baseBranchRef: string) => {
+  (context: Context<'push'>) => async (repository: RepositoryDetails, baseBranchRef: string) => {
     try {
-      app.log.debug(`Creating new branch on SHA: '${baseBranchRef}'.`)
+      console.debug(`Creating new branch on SHA: '${baseBranchRef}'.`)
       const newBranch = (
         await context.octokit.git.createRef({ ...repository, ref: fullBranchName, sha: baseBranchRef })
       ).data
-      app.log.debug(`Created new branch with ref: '${newBranch.ref}'.`)
+      console.debug(`Created new branch with ref: '${newBranch.ref}'.`)
       return newBranch
     } catch {
-      app.log.debug(`Failed to create a new branch with ref: '${fullBranchName}'.`)
-      app.log.debug(`Fetching existing branch with ref: '${reducedBranchName}'.`)
+      console.debug(`Failed to create a new branch with ref: '${fullBranchName}'.`)
+      console.debug(`Fetching existing branch with ref: '${reducedBranchName}'.`)
 
       const { data: foundBranch } = await context.octokit.git.getRef({ ...repository, ref: reducedBranchName })
-      app.log.debug(`Found new branch with ref: '${foundBranch.ref}'.`)
+      console.debug(`Found new branch with ref: '${foundBranch.ref}'.`)
 
       return foundBranch
     }
   }
 
 const createTreeWithChanges =
-  (app: Probot, context: Context<'push'>) =>
-  (templates: Template[], repository: RepositoryDetails) =>
-  async (treeSha: string) => {
+  (context: Context<'push'>) => (templates: Template[], repository: RepositoryDetails) => async (treeSha: string) => {
     const templateTree = templates.map(template => ({
       path: template.path,
       mode: '100644',
@@ -36,26 +34,26 @@ const createTreeWithChanges =
       content: template.contents,
     }))
 
-    app.log.debug(`Fetching existing trees from '${treeSha}'.`)
+    console.debug(`Fetching existing trees from '${treeSha}'.`)
     const {
       data: { tree: existingTree },
     } = await context.octokit.git.getTree({ ...repository, tree_sha: treeSha })
 
-    app.log.debug('Creating git tree with modified templates.')
+    console.debug('Creating git tree with modified templates.')
     const createdTree = await context.octokit.git.createTree({
       ...repository,
       tree: [...templateTree, ...existingTree] as [],
     })
-    app.log.debug(`Created git tree with SHA '${createdTree.data.sha}'.`)
+    console.debug(`Created git tree with SHA '${createdTree.data.sha}'.`)
 
     return createdTree
   }
 
 const createCommitWithChanges =
-  (app: Probot, context: Context<'push'>) =>
+  (context: Context<'push'>) =>
   (repository: RepositoryDetails, title: string) =>
   async (currentCommit: { data: { sha: string } }, createdTree: { data: { sha: string } }) => {
-    app.log.debug('Creating git commit with modified templates.')
+    console.debug('Creating git commit with modified templates.')
 
     const newCommit = await context.octokit.git.createCommit({
       ...repository,
@@ -63,17 +61,16 @@ const createCommitWithChanges =
       tree: createdTree.data.sha,
       parents: [currentCommit.data.sha],
     })
-    app.log.debug(`Created git commit with SHA '${newCommit.data.sha}'.`)
+    console.debug(`Created git commit with SHA '${newCommit.data.sha}'.`)
 
     return newCommit
   }
 
 const createPullRequest =
-  (app: Probot, context: Context<'push'>) =>
-  async (repository: RepositoryDetails, details: PRDetails, baseBranch: string) => {
+  (context: Context<'push'>) => async (repository: RepositoryDetails, details: PRDetails, baseBranch: string) => {
     const { title, description } = details
 
-    app.log.debug('Creating PR.')
+    console.debug('Creating PR.')
     const created = await context.octokit.pulls.create({
       ...repository,
       title,
@@ -81,70 +78,67 @@ const createPullRequest =
       head: fullBranchName,
       base: baseBranch,
     })
-    app.log.debug(`Created PR #${created.data.number}.`)
+    console.debug(`Created PR #${created.data.number}.`)
 
     return created
   }
 
-const updatePullRequest =
-  (app: Probot, context: Context<'push'>) => async (repository: RepositoryDetails, number: number) => {
-    app.log.debug(`Updating PR #${number}.`)
-    const updated = await context.octokit.pulls.update({
-      ...repository,
-      pull_number: number,
-      head: fullBranchName,
-      state: 'open',
-    })
-    app.log.debug(`Updated PR #${updated.data.number}.`)
+const updatePullRequest = (context: Context<'push'>) => async (repository: RepositoryDetails, number: number) => {
+  console.debug(`Updating PR #${number}.`)
+  const updated = await context.octokit.pulls.update({
+    ...repository,
+    pull_number: number,
+    head: fullBranchName,
+    state: 'open',
+  })
+  console.debug(`Updated PR #${updated.data.number}.`)
 
-    return updated
-  }
+  return updated
+}
 
-const getExistingPullRequest = (app: Probot, context: Context<'push'>) => async (repository: RepositoryDetails) => {
+const getExistingPullRequest = (context: Context<'push'>) => async (repository: RepositoryDetails) => {
   const { data: openPullRequests } = await context.octokit.pulls.list({
     ...repository,
     head: fullBranchName,
     state: 'open',
   })
-  app.log.debug(`Found ${openPullRequests.length} open PRs.`)
+  console.debug(`Found ${openPullRequests.length} open PRs.`)
 
   const toUpdate = openPullRequests.sort(pr => pr.number).shift()
 
   return toUpdate
 }
 
-const mergePullRequest =
-  (app: Probot, context: Context<'push'>) => async (number: number, repository: RepositoryDetails) => {
-    app.log.debug(`Attempting automerge of PR #${number}.`)
-    const merged = await context.octokit.rest.pulls.merge({
-      ...repository,
-      pull_number: number,
-      merge_method: 'squash',
-    })
-    app.log.debug(`Merged PR #${number}.`)
+const mergePullRequest = (context: Context<'push'>) => async (number: number, repository: RepositoryDetails) => {
+  console.debug(`Attempting automerge of PR #${number}.`)
+  const merged = await context.octokit.rest.pulls.merge({
+    ...repository,
+    pull_number: number,
+    merge_method: 'squash',
+  })
+  console.debug(`Merged PR #${number}.`)
 
-    return merged
-  }
+  return merged
+}
 
 const maintainPullRequest =
-  (app: Probot, context: Context<'push'>) =>
+  (context: Context<'push'>) =>
   async (repository: RepositoryDetails, details: PRDetails, baseBranch: string, automerge?: boolean) => {
-    const currentPullRequest = await getExistingPullRequest(app, context)(repository)
+    const currentPullRequest = await getExistingPullRequest(context)(repository)
 
     const pr = currentPullRequest
-      ? await updatePullRequest(app, context)(repository, currentPullRequest.number)
-      : await createPullRequest(app, context)(repository, details, baseBranch)
+      ? await updatePullRequest(context)(repository, currentPullRequest.number)
+      : await createPullRequest(context)(repository, details, baseBranch)
 
     if (automerge) {
-      await mergePullRequest(app, context)(pr.data.number, repository)
+      await mergePullRequest(context)(pr.data.number, repository)
     }
     return pr
   }
 
 const updateBranch =
-  (app: Probot, context: Context<'push'>) =>
-  async (newBranch: string, newCommit: string, repository: RepositoryDetails) => {
-    app.log.debug(`Setting new branch ref '${newBranch}' to commit '${newCommit}'.`)
+  (context: Context<'push'>) => async (newBranch: string, newCommit: string, repository: RepositoryDetails) => {
+    console.debug(`Setting new branch ref '${newBranch}' to commit '${newCommit}'.`)
     const {
       data: { ref: updatedRef },
     } = await context.octokit.git.updateRef({
@@ -176,13 +170,13 @@ const generatePullRequestDescription = (version: string, templates: Template[]) 
   `
 }
 
-export default (app: Probot, context: Context<'push'>) =>
+export default (context: Context<'push'>) =>
   async (repository: RepositoryDetails, version: string, templates: Template[]) => {
-    app.log.debug('Fetching base branch.')
+    console.debug('Fetching base branch.')
     const {
       data: { default_branch: baseBranch },
     } = await context.octokit.repos.get({ ...repository })
-    app.log.debug(`Fetching base branch ref 'heads/${baseBranch}'.`)
+    console.debug(`Fetching base branch ref 'heads/${baseBranch}'.`)
     const {
       data: {
         object: { sha: baseBranchRef },
@@ -191,29 +185,29 @@ export default (app: Probot, context: Context<'push'>) =>
 
     const {
       object: { sha: newBranch },
-    } = await getOrCreateNewBranch(app, context)(repository, baseBranchRef)
+    } = await getOrCreateNewBranch(context)(repository, baseBranchRef)
 
-    app.log.debug('Determining current commit.')
+    console.debug('Determining current commit.')
     const currentCommit = await context.octokit.git.getCommit({ ...repository, commit_sha: baseBranchRef })
 
-    app.log.debug(`Using base branch '${baseBranch}'.`)
-    app.log.debug(`Using base commit '${currentCommit.data.sha}'.`)
+    console.debug(`Using base branch '${baseBranch}'.`)
+    console.debug(`Using base commit '${currentCommit.data.sha}'.`)
 
     const prDetails = {
       title: 'Update templates based on repository configuration',
       description: generatePullRequestDescription(version, templates),
     }
 
-    const createdTree = await createTreeWithChanges(app, context)(templates, repository)(baseBranchRef)
+    const createdTree = await createTreeWithChanges(context)(templates, repository)(baseBranchRef)
     const {
       data: { sha: newCommit },
-    } = await createCommitWithChanges(app, context)(repository, prDetails.title)(currentCommit, createdTree)
-    const updatedRef = await updateBranch(app, context)(newBranch, newCommit, repository)
-    app.log.debug(`Updated branch ref: ${updatedRef}`)
+    } = await createCommitWithChanges(context)(repository, prDetails.title)(currentCommit, createdTree)
+    const updatedRef = await updateBranch(context)(newBranch, newCommit, repository)
+    console.debug(`Updated branch ref: ${updatedRef}`)
 
     const {
       data: { number },
-    } = await maintainPullRequest(app, context)(repository, prDetails, baseBranch)
+    } = await maintainPullRequest(context)(repository, prDetails, baseBranch)
 
     return number
   }

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,36 +1,35 @@
-import { Context, Probot } from 'probot'
+import { Context } from 'probot'
 import { loadAsync } from 'jszip'
 import { render } from 'mustache'
 import { RepositoryDetails, RepositoryConfiguration, TemplateInformation, Templates } from './types'
 import { OctokitResponse } from '@octokit/types'
 
-export const extractZipContents =
-  (app: Probot) => async (contents: ArrayBuffer, configuration: RepositoryConfiguration) => {
-    app.log.debug(`Extracting ZIP contents.`)
-    const loaded = await loadAsync(contents)
+export const extractZipContents = async (contents: ArrayBuffer, configuration: RepositoryConfiguration) => {
+  console.debug(`Extracting ZIP contents.`)
+  const loaded = await loadAsync(contents)
 
-    const toProcess = Promise.all(
-      configuration.files?.map(async file => {
-        const found = loaded.file(new RegExp(file.source))
-        app.log.debug(`Found ${found.length} file(s) matching ${file.source}. `)
-        const picked = found.shift()
-        if (picked) app.log.debug(`Using ${picked.name} for ${file.source}. `)
+  const toProcess = Promise.all(
+    configuration.files?.map(async file => {
+      const found = loaded.file(new RegExp(file.source))
+      console.debug(`Found ${found.length} file(s) matching ${file.source}. `)
+      const picked = found.shift()
+      if (picked) console.debug(`Using ${picked.name} for ${file.source}. `)
 
-        const text = (await picked?.async('text')) ?? ''
-        const contents = text?.replace(/#{{/gm, '{{')
+      const text = (await picked?.async('text')) ?? ''
+      const contents = text?.replace(/#{{/gm, '{{')
 
-        return {
-          path: file.destination,
-          contents,
-        }
-      }) ?? [],
-    )
+      return {
+        path: file.destination,
+        contents,
+      }
+    }) ?? [],
+  )
 
-    const templates = (await toProcess).filter(it => it?.contents)
-    app.log.debug(`Extracted ${templates.length} ZIP templates.`)
+  const templates = (await toProcess).filter(it => it?.contents)
+  console.debug(`Extracted ${templates.length} ZIP templates.`)
 
-    return templates
-  }
+  return templates
+}
 
 const getReleaseFromTag = (context: Context<'push'>) => (tag?: string) => {
   const getLatestRelease = async (repository: RepositoryDetails) => {
@@ -56,28 +55,28 @@ const getReleaseFromTag = (context: Context<'push'>) => (tag?: string) => {
 }
 
 export const downloadTemplates =
-  (app: Probot, context: Context<'push'>) =>
+  (context: Context<'push'>) =>
   async (templateVersion?: string): Promise<TemplateInformation> => {
     const templateRepository = {
       owner: process.env.TEMPLATE_REPOSITORY_OWNER ?? '',
       repo: process.env.TEMPLATE_REPOSITORY_NAME ?? '',
     }
 
-    app.log.debug(`Fetching templates from '${templateRepository.owner}/${templateRepository.repo}.`)
+    console.debug(`Fetching templates from '${templateRepository.owner}/${templateRepository.repo}.`)
     const release = await getReleaseFromTag(context)(templateVersion)(templateRepository)
-    app.log.debug(`Fetching templates from URL: '${release.zipball_url}'.`)
+    console.debug(`Fetching templates from URL: '${release.zipball_url}'.`)
 
     if (!release.zipball_url) {
-      app.log.error(`Release '${release.id}' has no zipball URL.`)
+      console.error(`Release '${release.id}' has no zipball URL.`)
       throw Error(`Release '${release.id}' has no zipball URL.`)
     }
 
-    app.log.debug(`Fetching release information from '${release.zipball_url}'.`)
+    console.debug(`Fetching release information from '${release.zipball_url}'.`)
     const { data: contents } = (await context.octokit.repos.downloadZipballArchive({
       ...templateRepository,
       ref: release.tag_name,
     })) as OctokitResponse<ArrayBuffer>
-    app.log.debug('Fetched release contents.')
+    console.debug('Fetched release contents.')
 
     return {
       contents,
@@ -86,20 +85,20 @@ export const downloadTemplates =
   }
 
 export const renderTemplates =
-  (app: Probot, context: Context<'push'>) =>
+  (context: Context<'push'>) =>
   async (configuration: RepositoryConfiguration): Promise<Templates> => {
-    app.log.debug('Processing configuration changes.')
+    console.debug('Processing configuration changes.')
     const { version } = configuration
-    app.log.debug(`Configuration uses template version '${version}'.`)
+    console.debug(`Configuration uses template version '${version}'.`)
 
-    const { contents, version: fetchedVersion } = await downloadTemplates(app, context)(version)
-    const templateContents = await extractZipContents(app)(contents, configuration)
+    const { contents, version: fetchedVersion } = await downloadTemplates(context)(version)
+    const templateContents = await extractZipContents(contents, configuration)
 
     const rendered = templateContents.map(template => ({
       ...template,
       contents: render(template.contents, configuration.values),
     }))
-    app.log.debug(`Processed ${rendered.length} templates.`)
+    console.debug(`Processed ${rendered.length} templates.`)
 
     return { version: fetchedVersion, templates: rendered }
   }


### PR DESCRIPTION
This updates all functions to _not_ take a `Probot` parameter. The only reason the logic currently looks this way is to allow calling `app.log.debug|info|warn`. 

Instead we use `console.debug|info|warn` to
- simplify the logic
- make it easier to test logic

Eventually we should use the logger underneath Probot ([`pino`](https://github.com/pinojs/pino)) to get really nice logging and ensure this logger is available for tests, but for now this will allow us to extend and test the logic without major loss of logging niceness.