### PR TITLE
Refactor functions to use Octokit directly instead of passing Context parameters

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -42,9 +42,9 @@ const processPushEvent = (branchesToProcess: RegExp) => async (payload: PushEven
     const configFileName = `.config/templates.yaml`
 
     if (filesChanged.includes(configFileName)) {
-      const parsed = await determineConfigurationChanges(octokit)(configFileName, repository, payload.after)
-      const { version, templates: processed } = await renderTemplates(octokit)(parsed)
-      const pullRequestNumber = await commitFiles(octokit)(repository, version, processed)
+      const parsed = await determineConfigurationChanges(configFileName, repository, payload.after)(octokit)
+      const { version, templates: processed } = await renderTemplates(parsed)(octokit)
+      const pullRequestNumber = await commitFiles(repository, version, processed)(octokit)
       console.info(`Committed templates to '${repository.owner}/${repository.repo}' in #${pullRequestNumber}`)
       console.info(`See: https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}`)
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,11 +1,10 @@
-import { Context } from 'probot'
 import { parse } from 'yaml'
-import { RepositoryDetails, RepositoryConfiguration } from './types'
+import { RepositoryDetails, RepositoryConfiguration, OctokitInterface } from './types'
 
 export const determineConfigurationChanges =
-  (context: Context<'push'>) => async (fileName: string, repository: RepositoryDetails, sha: string) => {
+  (octokit: OctokitInterface) => async (fileName: string, repository: RepositoryDetails, sha: string) => {
     console.debug(`Saw changes to ${fileName}.`)
-    const fileContents = await context.octokit.repos.getContent({
+    const fileContents = await octokit.repos.getContent({
       ...repository,
       path: fileName,
       ref: sha,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,8 +1,8 @@
 import { parse } from 'yaml'
-import { RepositoryDetails, RepositoryConfiguration, OctokitInterface } from './types'
+import { RepositoryDetails, RepositoryConfiguration, OctokitInstance } from './types'
 
 export const determineConfigurationChanges =
-  (octokit: OctokitInterface) => async (fileName: string, repository: RepositoryDetails, sha: string) => {
+  (fileName: string, repository: RepositoryDetails, sha: string) => async (octokit: OctokitInstance) => {
     console.debug(`Saw changes to ${fileName}.`)
     const fileContents = await octokit.repos.getContent({
       ...repository,

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,6 +1,6 @@
 import { loadAsync } from 'jszip'
 import { render } from 'mustache'
-import { RepositoryDetails, RepositoryConfiguration, TemplateInformation, Templates, OctokitInterface } from './types'
+import { RepositoryDetails, RepositoryConfiguration, TemplateInformation, Templates, OctokitInstance } from './types'
 import { OctokitResponse } from '@octokit/types'
 
 export const extractZipContents = async (contents: ArrayBuffer, configuration: RepositoryConfiguration) => {
@@ -30,39 +30,40 @@ export const extractZipContents = async (contents: ArrayBuffer, configuration: R
   return templates
 }
 
-const getReleaseFromTag = (octokit: OctokitInterface) => (tag?: string) => {
-  const getLatestRelease = async (repository: RepositoryDetails) => {
-    const latestRelease = await octokit.repos.getLatestRelease({
-      ...repository,
-    })
-    return latestRelease.data
-  }
-
-  const getRelease = async (repository: RepositoryDetails) => {
-    if (!tag) {
-      throw Error('A release tag is missing.')
+const getReleaseFromTag =
+  (tag: string | undefined, repository: RepositoryDetails) => async (octokit: OctokitInstance) => {
+    const getLatestRelease = async () => {
+      const latestRelease = await octokit.repos.getLatestRelease({
+        ...repository,
+      })
+      return latestRelease.data
     }
 
-    const release = await octokit.repos.getReleaseByTag({
-      ...repository,
-      tag,
-    })
-    return release.data
+    const getRelease = async () => {
+      if (!tag) {
+        throw Error('A release tag is missing.')
+      }
+
+      const release = await octokit.repos.getReleaseByTag({
+        ...repository,
+        tag,
+      })
+      return release.data
+    }
+
+    return tag ? getRelease() : getLatestRelease()
   }
 
-  return tag ? getRelease : getLatestRelease
-}
-
 export const downloadTemplates =
-  (octokit: OctokitInterface) =>
-  async (templateVersion?: string): Promise<TemplateInformation> => {
+  (templateVersion?: string) =>
+  async (octokit: OctokitInstance): Promise<TemplateInformation> => {
     const templateRepository = {
       owner: process.env.TEMPLATE_REPOSITORY_OWNER ?? '',
       repo: process.env.TEMPLATE_REPOSITORY_NAME ?? '',
     }
 
     console.debug(`Fetching templates from '${templateRepository.owner}/${templateRepository.repo}.`)
-    const release = await getReleaseFromTag(octokit)(templateVersion)(templateRepository)
+    const release = await getReleaseFromTag(templateVersion, templateRepository)(octokit)
     console.debug(`Fetching templates from URL: '${release.zipball_url}'.`)
 
     if (!release.zipball_url) {
@@ -84,13 +85,13 @@ export const downloadTemplates =
   }
 
 export const renderTemplates =
-  (octokit: OctokitInterface) =>
-  async (configuration: RepositoryConfiguration): Promise<Templates> => {
+  (configuration: RepositoryConfiguration) =>
+  async (octokit: OctokitInstance): Promise<Templates> => {
     console.debug('Processing configuration changes.')
     const { version } = configuration
     console.debug(`Configuration uses template version '${version}'.`)
 
-    const { contents, version: fetchedVersion } = await downloadTemplates(octokit)(version)
+    const { contents, version: fetchedVersion } = await downloadTemplates(version)(octokit)
     const templateContents = await extractZipContents(contents, configuration)
 
     const rendered = templateContents.map(template => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,4 +36,4 @@ export interface PRDetails {
   description: string
 }
 
-export type OctokitInterface = InstanceType<typeof ProbotOctokit>
+export type OctokitInstance = InstanceType<typeof ProbotOctokit>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { ProbotOctokit } from 'probot'
 interface PathConfiguration {
   source: string
   destination: string
@@ -34,3 +35,5 @@ export interface PRDetails {
   title: string
   description: string
 }
+
+export type OctokitInterface = InstanceType<typeof ProbotOctokit>


### PR DESCRIPTION
This will refactor the app logic to take the required `Octokit` type instead of passing the full `Context` around. This refactor also moves the passing of the required `Octokit` type to the end of the function chains to allow preparing work and executing it at a later stage when an instance of Octokit is passed. 

This will make testing easier and make it more clear what the functions actually do based on the parameters they require.

