### PR TITLE
Use GitHub Action-compatible delimiters for template rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The app then pulls the repository configuration, downloads templates and process
 Processed templates are then submitted to the repository as a PR. If `automerge` is enabled, the PR is merged automatically.
 
 ## Templates
-Templates support the full [Mustache template language](https://mustache.github.io) tags. 
+Templates support the full [Mustache template language](https://mustache.github.io) tags with the delimiters `<<<` and `>>>`.
 
 Logic is handled as follows using a `YAML` template as an example:
 ```yaml
@@ -48,19 +48,19 @@ on:
 jobs:
   build:
     steps:
-      - name: Checkout {{repositoryName}}
+      - name: Checkout <<<repositoryName>>>
         uses: actions/checkout@v3.0.2
-        #{{^shouldCheckoutCode}}
+        #<<<^shouldCheckoutCode>>>
         if: false
-        #{{/shouldCheckoutCode}}
+        #<<</shouldCheckoutCode>>>
 
-      #{{#shouldLoginToDockerHub}}
+      #<<<#shouldLoginToDockerHub>>>
       - name: Login to DockerHub
         uses: docker/login-action@v2.0.0
         with:
           username: pleodeployments
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      #{{/shouldLoginToDockerHub}}
+          password: $<<< secrets.DOCKERHUB_TOKEN >>>
+      #<<</shouldLoginToDockerHub>>>
 ```
 
 See the [Mustache manual](https://mustache.github.io/mustache.5.html) for more information on the template syntax.

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -98,9 +98,10 @@ export const renderTemplates =
     const { contents, version: fetchedVersion } = await downloadTemplates(version)(log)(octokit)
     const templateContents = await extractZipContents(contents, configuration)(log)
 
+    const delimiters: [string, string] = ['<<<', '>>>']
     const rendered = templateContents.map(template => ({
       ...template,
-      contents: render(template.contents, configuration.values),
+      contents: render(template.contents, configuration.values, {}, delimiters),
     }))
     log.debug(`Processed ${rendered.length} templates.`)
 

--- a/test/templates.test.ts
+++ b/test/templates.test.ts
@@ -7,8 +7,8 @@ import { OctokitInstance } from '../src/types'
 const stubTemplates = async (): Promise<ArrayBuffer> => {
   const zip = new JSZip()
   return zip
-    .file('templates/test_template.json', '{"owner": "pleo", "repo": "{{appName}}"}')
-    .file('templates/test_template.toml', 'owner = "pleo" repo = "{{appName}}"')
+    .file('templates/test_template.json', '{"owner": "pleo", "repo": "<<<appName>>>"}')
+    .file('templates/test_template.toml', 'owner = "pleo" repo = "<<<appName>>>"')
     .generateAsync({ type: 'arraybuffer', streamFiles: true })
 }
 


### PR DESCRIPTION
This will use the GitHub Actions-compatible delimiters `['<<<', '>>>']` for template rendering. The existing `{{` and `}}` delimiters are not compatible with GitHub Actions' `${{ ... }}` delimiters.