### PR TITLE
Prefer SWC only in tests and CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build
         run: |
-          yarn build
+          yarn build:swc
 
       - name: Lint
         run: |


### PR DESCRIPTION
`docker build` doesn't like `swc`, so we only use it for testing and CI to speed these up, but avoid using it for distributed images.