### PR TITLE
Avoid creating PRs with no changes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -116,7 +116,7 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
 
 const processPushEvent = async (payload: PushEvent, context: Context<'push'>) => {
   const { log, octokit } = context
-  const { commitFiles, getCommitFiles } = git(log, octokit)
+  const { commitFilesToPR, getCommitFiles } = git(log, octokit)
   const { combineConfigurations, determineConfigurationChanges } = configuration(log, octokit)
   const { getTemplateInformation, renderTemplates } = templates(log, octokit)
 
@@ -141,7 +141,7 @@ const processPushEvent = async (payload: PushEvent, context: Context<'push'>) =>
   if (!combined) return
 
   const { version, templates: processed } = await renderTemplates(combined)
-  const pullRequestNumber = await commitFiles(repository, version, processed)
+  const pullRequestNumber = await commitFilesToPR(repository, version, processed)
 
   if (!pullRequestNumber) {
     log.info('Commit leads to no changes.')

--- a/src/app.ts
+++ b/src/app.ts
@@ -142,6 +142,12 @@ const processPushEvent = async (payload: PushEvent, context: Context<'push'>) =>
 
   const { version, templates: processed } = await renderTemplates(combined)
   const pullRequestNumber = await commitFiles(repository, version, processed)
+
+  if (!pullRequestNumber) {
+    log.info('Commit leads to no changes.')
+    log.info('Skipped PR creation.')
+  }
+
   log.info('Committed templates to %s/%s in #%d', repository.owner, repository.repo, pullRequestNumber)
   log.info('See: https://github.com/%s/%S/pull/%d', repository.owner, repository.repo, pullRequestNumber)
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -181,7 +181,7 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
     return merged
   }
 
-  const maintainPullRequest = async (
+  const createOrUpdatePullRequest = async (
     repository: RepositoryDetails,
     details: PRDetails,
     baseBranch: string,
@@ -269,7 +269,11 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
     return filenames
   }
 
-  const commitFiles = async (repository: RepositoryDetails, version: string, templates: Template[]) => {
+  const commitFilesToPR = async (
+    repository: RepositoryDetails,
+    version: string,
+    templates: Template[],
+  ): Promise<number | undefined> => {
     const { baseBranch, currentCommitSha, newBranch, baseBranchRef } = await extractBranchInformation(repository)
 
     const title = 'Update templates based on repository configuration'
@@ -288,7 +292,7 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
       description: generatePullRequestDescription(version, changes),
     }
 
-    return maintainPullRequest(repository, prDetails, baseBranch)
+    return createOrUpdatePullRequest(repository, prDetails, baseBranch)
   }
 
   const requestPullRequestChanges = async (
@@ -350,7 +354,7 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
 
   return {
     approvePullRequestChanges,
-    commitFiles,
+    commitFilesToPR,
     getCommitFiles,
     getFilesChanged,
     requestPullRequestChanges,

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -184,6 +184,7 @@ describe('Probot Tests', () => {
       .reply(200, { object: { sha: 'newBranch' } })
     baseNock.get('/repos/pleo-oss/test/git/commits/baseBranchRef').reply(200, { sha: 'currentCommitSha' })
     baseNock.get('/repos/pleo-oss/test/git/trees/baseBranchRef').reply(200, { tree: 'existingTree' })
+    baseNock.get('/repos/pleo-oss/test/compare/baseBranch...newBranch').reply(200, { files: ['somefile'] })
     baseNock.post('/repos/pleo-oss/test/git/trees').reply(200, { sha: 'createdTreeSha' })
     baseNock.post('/repos/pleo-oss/test/git/commits').reply(200, { sha: 'newCommitSha' })
     baseNock.patch('/repos/pleo-oss/test/git/refs/heads%2Fcentralized-templates').reply(200, { ref: 'updatedRef' })

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -109,8 +109,8 @@ describe('Probot Tests', () => {
   })
 
   test('can handle empty files in commit', async () => {
-    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
     baseNock.get('/repos/pleo-oss/test/commits/sha').reply(200, { files: [] })
+    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
 
     const pushEvent = {
       name: 'push',
@@ -128,8 +128,8 @@ describe('Probot Tests', () => {
   })
 
   test('can handle non-config files in commit', async () => {
-    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
     baseNock.get('/repos/pleo-oss/test/commits/sha').reply(200, { files: [{ filename: 'somefile.txt' }] })
+    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
 
     const pushEvent = {
       name: 'push',
@@ -147,8 +147,8 @@ describe('Probot Tests', () => {
   })
 
   test('can handle error requests', async () => {
-    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
     baseNock.get('/repos/pleo-oss/test/commits/sha').reply(500, {})
+    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
 
     const pushEvent = {
       name: 'push',
@@ -166,30 +166,29 @@ describe('Probot Tests', () => {
   })
 
   test('can fetch changes, fetch configuration changes, render templates, create PR (smoke test)', async () => {
-    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
+    baseNock.get('/repos/pleo-oss/template-repository/zipball/0.0.7').reply(200, zipContents)
+    baseNock.get('/repos/pleo-oss/test').reply(200, { default_branch: 'baseBranch' })
     baseNock.get('/repos/pleo-oss/test/commits/sha').reply(200, { files: [{ filename: '.github/templates.yaml' }] })
+    baseNock.get('/repos/pleo-oss/test/compare/baseBranch...newBranch').reply(200, { files: ['somefile'] })
     baseNock
       .get('/repos/pleo-oss/test/contents/.github%2Ftemplates.yaml?ref=sha')
       .reply(200, { content: Buffer.from(JSON.stringify(configuration)).toString('base64') })
-    baseNock
-      .persist()
-      .get('/repos/pleo-oss/template-repository/releases/tags/v0.0.7')
-      .reply(200, { zipball_url: 'test', tag_name: '0.0.7' })
-
-    baseNock.get('/repos/pleo-oss/template-repository/zipball/0.0.7').reply(200, zipContents)
-    baseNock.get('/repos/pleo-oss/test').reply(200, { default_branch: 'baseBranch' })
+    baseNock.get('/repos/pleo-oss/test/git/commits/baseBranchRef').reply(200, { sha: 'currentCommitSha' })
     baseNock.get('/repos/pleo-oss/test/git/ref/heads%2FbaseBranch').reply(200, { object: { sha: 'baseBranchRef' } })
     baseNock
       .get('/repos/pleo-oss/test/git/ref/heads%2Fcentralized-templates')
       .reply(200, { object: { sha: 'newBranch' } })
-    baseNock.get('/repos/pleo-oss/test/git/commits/baseBranchRef').reply(200, { sha: 'currentCommitSha' })
     baseNock.get('/repos/pleo-oss/test/git/trees/baseBranchRef').reply(200, { tree: 'existingTree' })
-    baseNock.get('/repos/pleo-oss/test/compare/baseBranch...newBranch').reply(200, { files: ['somefile'] })
-    baseNock.post('/repos/pleo-oss/test/git/trees').reply(200, { sha: 'createdTreeSha' })
-    baseNock.post('/repos/pleo-oss/test/git/commits').reply(200, { sha: 'newCommitSha' })
-    baseNock.patch('/repos/pleo-oss/test/git/refs/heads%2Fcentralized-templates').reply(200, { ref: 'updatedRef' })
-    baseNock.get('/repos/pleo-oss/test/pulls?head=refs/heads/centralized-templates&state=open').reply(200, [])
     baseNock.get('/repos/pleo-oss/test/pulls?head=pleo-oss:centralized-templates&state=open').reply(200, [])
+    baseNock.get('/repos/pleo-oss/test/pulls?head=refs/heads/centralized-templates&state=open').reply(200, [])
+    baseNock.patch('/repos/pleo-oss/test/git/refs/heads%2Fcentralized-templates').reply(200, { ref: 'updatedRef' })
+    baseNock
+      .persist()
+      .get('/repos/pleo-oss/template-repository/releases/tags/v0.0.7')
+      .reply(200, { zipball_url: 'test', tag_name: '0.0.7' })
+    baseNock.post('/app/installations/2/access_tokens').reply(200, { token: 'testToken' })
+    baseNock.post('/repos/pleo-oss/test/git/commits').reply(200, { sha: 'newCommitSha' })
+    baseNock.post('/repos/pleo-oss/test/git/trees').reply(200, { sha: 'createdTreeSha' })
     baseNock.post('/repos/pleo-oss/test/pulls').reply(200, { number: 'prNumber' })
 
     const errorSpy = jest.spyOn(console, 'error').mockImplementation()
@@ -239,17 +238,12 @@ describe('Probot Tests', () => {
   })
 
   test('can receive a pull request event with a template configuration change and process the event', async () => {
-    baseNock.get('/repos/pleo-oss/test/pulls/27/files').reply(200, [
-      {
-        filename: '.github/templates.yaml',
-      },
-    ])
     baseNock
       .get('/repos/pleo-oss/test/contents/.github/templates.yaml?ref=sha')
       .reply(200, { content: Buffer.from(JSON.stringify(configuration)).toString('base64') })
-
-    baseNock.post('/repos/pleo-oss/test/check-runs').reply(200)
+    baseNock.get('/repos/pleo-oss/test/pulls/27/files').reply(200, [{ filename: '.github/templates.yaml' }])
     baseNock.patch('/repos/pleo-oss/test/check-runs/').reply(200)
+    baseNock.post('/repos/pleo-oss/test/check-runs').reply(200)
     baseNock.post('/repos/pleo-oss/test/pulls/27/reviews').reply(200)
 
     const pullRequestEvent = {
@@ -272,20 +266,13 @@ describe('Probot Tests', () => {
   })
 
   test('can receive a pull request event with a wrong template configuration change and process the event', async () => {
-    baseNock.get('/repos/pleo-oss/test/pulls/27/files').reply(200, [
-      {
-        filename: '.github/templates.yaml',
-      },
-    ])
-
     configuration.version = 'Version not following pattern'
-
     baseNock
       .get('/repos/pleo-oss/test/contents/.github/templates.yaml?ref=sha')
       .reply(200, { content: Buffer.from(JSON.stringify(configuration)).toString('base64') })
-
-    baseNock.post('/repos/pleo-oss/test/check-runs').reply(200)
+    baseNock.get('/repos/pleo-oss/test/pulls/27/files').reply(200, [{ filename: '.github/templates.yaml' }])
     baseNock.patch('/repos/pleo-oss/test/check-runs/').reply(200)
+    baseNock.post('/repos/pleo-oss/test/check-runs').reply(200)
     baseNock.post('/repos/pleo-oss/test/pulls/27/reviews').reply(200)
 
     const pullRequestEvent = {

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -18,29 +18,64 @@ describe('Pull Request reviews', () => {
       get: jest.fn(() => {
         return {
           data: {
-            default_branch: 'main'
-          }
+            default_branch: 'main',
+          },
         }
-      })
+      }),
+      compareCommits: jest.fn(() => {
+        return {
+          data: {
+            files: [],
+          },
+        }
+      }),
     },
     git: {
       getRef: jest.fn(() => {
         return {
           data: {
             object: {
-              sha: 'sha'
-            }
-          }
+              sha: 'sha',
+            },
+          },
         }
       }),
       getCommit: jest.fn(() => {
         return {
           data: {
-            sha: 'shaCurrentCommit'
-          }
+            sha: 'shaCurrentCommit',
+          },
         }
-      })
-    }
+      }),
+      getTree: jest.fn(() => {
+        return {
+          data: {
+            tree: [],
+          },
+        }
+      }),
+      createCommit: jest.fn(() => {
+        return {
+          data: {
+            sha: 'createTreeSha',
+          },
+        }
+      }),
+      createTree: jest.fn(() => {
+        return {
+          data: {
+            sha: 'createdTreeSha',
+          },
+        }
+      }),
+      updateRef: jest.fn(() => {
+        return {
+          data: {
+            ref: 'updatedRef',
+          },
+        }
+      }),
+    },
   } as unknown as OctokitInstance
 
   const testRepository = {
@@ -50,7 +85,7 @@ describe('Pull Request reviews', () => {
 
   const testPullRequestNumber = 1
 
-  const { approvePullRequestChanges, requestPullRequestChanges, commitFiles } = git(log, octokitMock)
+  const { approvePullRequestChanges, requestPullRequestChanges, commitFilesToPR } = git(log, octokitMock)
 
   describe('Create reviews', () => {
     beforeEach(() => {
@@ -104,8 +139,118 @@ Check the PR comments for any additional errors.`
   })
 
   describe('Commit files', () => {
-    test('can commit files', async () => {
-      const result = await commitFiles(testRepository, 'v1.0,0', [])
+    test('when no changes return undefined', async () => {
+      const result = await commitFilesToPR(testRepository, 'v1.0,0', [])
+      expect(octokitMock.repos.compareCommits).toBeCalledTimes(1)
+
+      expect(result).toBeUndefined()
+    })
+
+    test('when changes ', async () => {
+      const octokitMockDifferentFiles = {
+        pulls: {
+          createReview: jest.fn(() => {
+            return {
+              data: {
+                id: 'reviewId',
+              },
+            }
+          }),
+          list: jest.fn(() => {
+            return {
+              data: [],
+            }
+          }),
+          create: jest.fn(() => {
+            return {
+              data: {
+                number: 1,
+              },
+            }
+          }),
+        },
+        repos: {
+          get: jest.fn(() => {
+            return {
+              data: {
+                default_branch: 'main',
+              },
+            }
+          }),
+          compareCommits: jest.fn(() => {
+            return {
+              data: {
+                files: [
+                  {
+                    filename: 'test',
+                  },
+                ],
+              },
+            }
+          }),
+        },
+        git: {
+          getRef: jest.fn(() => {
+            return {
+              data: {
+                object: {
+                  sha: 'sha',
+                },
+              },
+            }
+          }),
+          getCommit: jest.fn(() => {
+            return {
+              data: {
+                sha: 'shaCurrentCommit',
+              },
+            }
+          }),
+          getTree: jest.fn(() => {
+            return {
+              data: {
+                tree: [],
+              },
+            }
+          }),
+          createCommit: jest.fn(() => {
+            return {
+              data: {
+                sha: 'createTreeSha',
+              },
+            }
+          }),
+          createTree: jest.fn(() => {
+            return {
+              data: {
+                sha: 'createdTreeSha',
+              },
+            }
+          }),
+          updateRef: jest.fn(() => {
+            return {
+              data: {
+                ref: 'updatedRef',
+              },
+            }
+          }),
+        },
+        issues: {
+          setLabers: jest.fn(() => {
+            return {
+              data: {},
+            }
+          }),
+        },
+      } as unknown as OctokitInstance
+      const { commitFilesToPR } = git(log, octokitMockDifferentFiles)
+
+      const result = await commitFilesToPR(testRepository, 'v1.0,0', [])
+      expect(octokitMockDifferentFiles.repos.compareCommits).toBeCalledTimes(1)
+      expect(octokitMockDifferentFiles.pulls.list).toBeCalledTimes(1)
+      expect(octokitMockDifferentFiles.pulls.create).toBeCalledTimes(1)
+
+      expect(result).toBe(1)
     })
   })
 })

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -14,6 +14,33 @@ describe('Pull Request reviews', () => {
         }
       }),
     },
+    repos: {
+      get: jest.fn(() => {
+        return {
+          data: {
+            default_branch: 'main'
+          }
+        }
+      })
+    },
+    git: {
+      getRef: jest.fn(() => {
+        return {
+          data: {
+            object: {
+              sha: 'sha'
+            }
+          }
+        }
+      }),
+      getCommit: jest.fn(() => {
+        return {
+          data: {
+            sha: 'shaCurrentCommit'
+          }
+        }
+      })
+    }
   } as unknown as OctokitInstance
 
   const testRepository = {
@@ -23,7 +50,7 @@ describe('Pull Request reviews', () => {
 
   const testPullRequestNumber = 1
 
-  const { approvePullRequestChanges, requestPullRequestChanges } = git(log, octokitMock)
+  const { approvePullRequestChanges, requestPullRequestChanges, commitFiles } = git(log, octokitMock)
 
   describe('Create reviews', () => {
     beforeEach(() => {
@@ -73,6 +100,12 @@ Check the PR comments for any additional errors.`
         body: expectedBody,
       })
       expect(result).toEqual('reviewId')
+    })
+  })
+
+  describe('Commit files', () => {
+    test('can commit files', async () => {
+      const result = await commitFiles(testRepository, 'v1.0,0', [])
     })
   })
 })


### PR DESCRIPTION
This will avoid creating PRs with 0 changed files. This is accomplished by comparing the base branch (the default branch) with the branch created for the configuration changes.