### PR TITLE
Send comment on PR errors per line

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -77,10 +77,10 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
     log.debug(`Requested changes for PR #${number} in ${changeRequestId}.`)
   }
 
-  if (versionCheckConclusion === 'failure') return
+  if (versionCheckConclusion === 'failure' || !configurationChanges.repositoryConfiguration) return
 
   const { configuration: templateConfiguration, files } = await getTemplateInformation(
-    configurationChanges.repositoryConfiguration.version,
+    configurationChanges.repositoryConfiguration?.version,
   )
   const defaultValueSchema = generateSchema(templateConfiguration.values)
 
@@ -97,7 +97,7 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
   const validatedFiles = validateFiles(combined, files)
 
   const result = validatedTemplates.result && validatedFiles.result
-  const errors = validatedTemplates.errors && validatedFiles.errors
+  const errors = validatedTemplates.errors.concat(validatedFiles.errors)
   const onlyChangesConfiguration = filesChanged.length === 1 && filesChanged[0] === configFileName
 
   if (!result) {

--- a/src/app.ts
+++ b/src/app.ts
@@ -133,6 +133,8 @@ const processPushEvent = async (payload: PushEvent, context: Context<'push'>) =>
   if (!filesChanged.includes(configFileName)) return
 
   const parsed = await determineConfigurationChanges(configFileName, repository, payload.after)
+
+  if (!parsed.repositoryConfiguration) return
   const { configuration: defaultValues } = await getTemplateInformation(parsed.repositoryConfiguration.version)
 
   const combined = combineConfigurations(defaultValues, parsed.repositoryConfiguration)

--- a/src/app.ts
+++ b/src/app.ts
@@ -79,17 +79,21 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
 
   if (versionCheckConclusion === 'failure') return
 
-  const { configuration: templateConfiguration, files } = await getTemplateInformation(configurationChanges.repositoryConfiguration.version)
+  const { configuration: templateConfiguration, files } = await getTemplateInformation(
+    configurationChanges.repositoryConfiguration.version,
+  )
   const defaultValueSchema = generateSchema(templateConfiguration.values)
 
   const combined = combineConfigurations(templateConfiguration, configurationChanges.repositoryConfiguration)
   if (!combined) return
 
-  const validatedTemplates = validateTemplateConfiguration({
-    repositoryConfiguration: combined,
-    cstYamlRepresentation: configurationChanges.cstYamlRepresentation
-  },
-    defaultValueSchema)
+  const validatedTemplates = validateTemplateConfiguration(
+    {
+      repositoryConfiguration: combined,
+      cstYamlRepresentation: configurationChanges.cstYamlRepresentation,
+    },
+    defaultValueSchema,
+  )
   const validatedFiles = validateFiles(combined, files)
 
   const result = validatedTemplates.result && validatedFiles.result

--- a/src/app.ts
+++ b/src/app.ts
@@ -73,27 +73,31 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
   })
 
   if (!versionResult) {
-    const changeRequestId = await requestPullRequestChanges(repository, number, versionErrors)
+    const changeRequestId = await requestPullRequestChanges(repository, number, configFileName, versionErrors)
     log.debug(`Requested changes for PR #${number} in ${changeRequestId}.`)
   }
 
   if (versionCheckConclusion === 'failure') return
 
-  const { configuration: templateConfiguration, files } = await getTemplateInformation(configurationChanges.version)
+  const { configuration: templateConfiguration, files } = await getTemplateInformation(configurationChanges.repositoryConfiguration.version)
   const defaultValueSchema = generateSchema(templateConfiguration.values)
 
-  const combined = combineConfigurations(templateConfiguration, configurationChanges)
+  const combined = combineConfigurations(templateConfiguration, configurationChanges.repositoryConfiguration)
   if (!combined) return
 
-  const validatedTemplates = validateTemplateConfiguration(combined, defaultValueSchema)
+  const validatedTemplates = validateTemplateConfiguration({
+    repositoryConfiguration: combined,
+    cstYamlRepresentation: configurationChanges.cstYamlRepresentation
+  },
+    defaultValueSchema)
   const validatedFiles = validateFiles(combined, files)
 
   const result = validatedTemplates.result && validatedFiles.result
-  const errors = validatedTemplates.errors.concat(validatedFiles.errors)
+  const errors = validatedTemplates.errors && validatedFiles.errors
   const onlyChangesConfiguration = filesChanged.length === 1 && filesChanged[0] === configFileName
 
   if (!result) {
-    const changeRequestId = await requestPullRequestChanges(repository, number, errors)
+    const changeRequestId = await requestPullRequestChanges(repository, number, configFileName, errors)
     log.debug(`Requested changes for PR #%d in %s.`, number, changeRequestId)
   } else if (onlyChangesConfiguration) {
     const approvedReviewId = await approvePullRequestChanges(repository, number)
@@ -125,9 +129,9 @@ const processPushEvent = async (payload: PushEvent, context: Context<'push'>) =>
   if (!filesChanged.includes(configFileName)) return
 
   const parsed = await determineConfigurationChanges(configFileName, repository, payload.after)
-  const { configuration: defaultValues } = await getTemplateInformation(parsed.version)
+  const { configuration: defaultValues } = await getTemplateInformation(parsed.repositoryConfiguration.version)
 
-  const combined = combineConfigurations(defaultValues, parsed)
+  const combined = combineConfigurations(defaultValues, parsed.repositoryConfiguration)
   if (!combined) return
 
   const { version, templates: processed } = await renderTemplates(combined)

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -52,7 +52,7 @@ export const configuration = (log: Logger, octokit: Pick<OctokitInstance, 'repos
 
     const rep = {
       tokens: tokens,
-      lines: lineCounter.lineStarts
+      lines: lineCounter.lineStarts,
     }
 
     const parsed: RepositoryConfiguration = parse(decodedContent)
@@ -72,7 +72,7 @@ export const configuration = (log: Logger, octokit: Pick<OctokitInstance, 'repos
 
     return {
       repositoryConfiguration: combinedConfiguration,
-      cstYamlRepresentation: rep
+      cstYamlRepresentation: rep,
     } as TemplateConfig
   }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,6 +1,6 @@
 import { Logger } from 'probot'
-import { parse } from 'yaml'
-import { RepositoryDetails, RepositoryConfiguration, OctokitInstance, PathConfiguration } from './types'
+import { LineCounter, parse, Parser } from 'yaml'
+import { RepositoryDetails, RepositoryConfiguration, OctokitInstance, PathConfiguration, TemplateConfig } from './types'
 
 export const combineConfigurations = (
   base: RepositoryConfiguration,
@@ -45,6 +45,16 @@ export const configuration = (log: Logger, octokit: Pick<OctokitInstance, 'repos
     const decodedContent = Buffer.from(content, 'base64').toString()
     log.debug('%s contains: %s', fileName, decodedContent)
 
+    const lineCounter = new LineCounter()
+
+    const cst = new Parser(lineCounter.addNewLine).parse(decodedContent)
+    const tokens = Array.from(cst)
+
+    const rep = {
+      tokens: tokens,
+      lines: lineCounter.lineStarts
+    }
+
     const parsed: RepositoryConfiguration = parse(decodedContent)
     log.debug('Saw configuration file contents %o', parsed)
 
@@ -60,7 +70,10 @@ export const configuration = (log: Logger, octokit: Pick<OctokitInstance, 'repos
 
     log.debug('Saw combined configuration contents %o', combinedConfiguration)
 
-    return combinedConfiguration
+    return {
+      repositoryConfiguration: combinedConfiguration,
+      cstYamlRepresentation: rep
+    } as TemplateConfig
   }
 
   return {

--- a/src/git.ts
+++ b/src/git.ts
@@ -278,14 +278,15 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
     configFileName: string,
     errors: ValidationError[],
   ) => {
-
     const errorsWithoutLine = errors.filter(e => !e.line)
 
-    const comments = errors.filter(e => e.line).map(e => ({
-      path: configFileName,
-      body: e.message ?? '',
-      line: e.line,
-    }))
+    const comments = errors
+      .filter(e => e.line)
+      .map(e => ({
+        path: configFileName,
+        body: e.message ?? '',
+        line: e.line,
+      }))
 
     let body = `🤖 It looks like your template changes are invalid.\n\n`
 
@@ -304,7 +305,7 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
       pull_number: pullRequestNumber,
       event: 'REQUEST_CHANGES',
       body,
-      comments
+      comments,
     })
 
     log.debug("Created change request review '%d'.", id)

--- a/src/git.ts
+++ b/src/git.ts
@@ -295,7 +295,7 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
         ${errorsWithoutLine.map(e => `- ${e.message}`).join('\n')}`)
     }
 
-    body = body.concat('\nCheck the PR comments for any additional error.')
+    body = body.concat('\nCheck the PR comments for any additional errors.')
 
     log.debug('Creating change request review on PR #%d.', pullRequestNumber)
     const {

--- a/src/git.ts
+++ b/src/git.ts
@@ -284,7 +284,7 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
       .filter(e => e.line)
       .map(e => ({
         path: configFileName,
-        body: e.message ?? '',
+        body: `\`${e.message}\`` ?? '',
         line: e.line,
       }))
 
@@ -292,10 +292,10 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
 
     if (errorsWithoutLine) {
       body = body.concat(`There were the following errors:
-        ${errorsWithoutLine.map(e => `- ${e.message}`).join('\n')}`)
+        ${errorsWithoutLine.map(e => `- \`${e.message}\``).join('\n')}`)
     }
 
-    body = body.concat('\nCheck the PR comments for any additional errors.')
+    body = body.concat('\n\nCheck the PR comments for any additional errors.')
 
     log.debug('Creating change request review on PR #%d.', pullRequestNumber)
     const {

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -1,12 +1,79 @@
-import { ConfigurationValues, RepositoryConfiguration, TemplateValidation } from './types'
+/* eslint-disable no-console */
+import { ConfigurationValues, CSTRepresentation, RepositoryConfiguration, TemplateConfig, TemplateValidation } from './types'
 import Ajv, { ErrorObject } from 'ajv'
 import templateSchema from './template-schema.json'
 import { Logger } from 'probot'
 import { createSchema } from 'genson-js'
 import { ensurePathConfiguration } from './configuration'
+import { CST } from 'yaml'
+import { Document, SourceToken } from 'yaml/dist/parse/cst'
 
-const ajv = new Ajv({ allowUnionTypes: true })
+const ajv = new Ajv({ allowUnionTypes: true, allErrors: true })
 const validateConfiguration = ajv.compile<RepositoryConfiguration>(templateSchema)
+
+
+const getLineFromOffset = (lines: number[], offset: number): number => {
+  for (let index = 1; index < lines.length; index++) {
+    const newLineOffset = lines[index];
+    if (newLineOffset > offset) {
+      return index
+    }
+  }
+  return -1
+}
+
+const getLineFromInstancePath = (instancePath: string, cst: CSTRepresentation): number | undefined => {
+  const pathItems = instancePath.split('/').slice(1)
+
+
+  const getLineFromDoc = (doc: Document) => {
+    let line = undefined
+    CST.visit(doc, (item, path) => {
+
+      const currentPathValue = pathItems[path.length - 1]
+      const num = Number(currentPathValue)
+      // If path step is a number
+      if (isNaN(num)) {
+        if (!CST.isScalar(item.value)) return
+
+        const key = item.key as SourceToken
+
+        if (key.source !== currentPathValue) {
+          return CST.visit.SKIP
+        }
+        if (path.length === pathItems.length) {
+          const index = getLineFromOffset(cst.lines, key.offset)
+          if (index > 0) {
+            line = index
+            return CST.visit.BREAK
+          }
+        }
+      } else {
+        if (num !== path[path.length - 1][1]) {
+          return CST.visit.SKIP
+        }
+
+        if (!CST.isScalar(item.value)) return
+
+        if (path.length === pathItems.length) {
+          const index = getLineFromOffset(cst.lines, item.value.offset)
+          if (index > 0) {
+            line = index
+            return CST.visit.BREAK
+          }
+        }
+      }
+      return
+    })
+    return line
+  }
+
+  for (const t of cst.tokens) {
+    const l = getLineFromDoc(t as Document)
+    if (l !== undefined) return l
+  }
+  return
+}
 
 export const schemaValidator = (log: Logger) => {
   const prettifyErrors = (errors?: ErrorObject<string, Record<string, unknown>, unknown>[] | null) =>
@@ -18,15 +85,23 @@ export const schemaValidator = (log: Logger) => {
       ?.filter(error => error !== '') ?? []
 
   const validateTemplateConfiguration = (
-    configuration?: RepositoryConfiguration,
+    configuration: TemplateConfig,
     valuesSchema?: string,
   ): TemplateValidation => {
     const validateValues = ajv.compile<ConfigurationValues>(JSON.parse(valuesSchema ?? '{}'))
-    const isValidConfiguration = validateConfiguration(configuration)
-    const hasValidValues = validateValues(configuration?.values)
+    const isValidConfiguration = validateConfiguration(configuration?.repositoryConfiguration)
+    const hasValidValues = validateValues(configuration?.repositoryConfiguration?.values)
+
+    const validationErrors = validateConfiguration.errors?.map(e => (
+      {
+        message: e.message,
+        line: getLineFromInstancePath(e.instancePath, configuration.cstYamlRepresentation)
+      }
+    ))
+
+    const validationValueErrors = validateValues.errors?.map(e => ({ message: e.message, line: undefined }))
 
     const configurationErrors = prettifyErrors(validateConfiguration.errors)
-    const valueErrors = prettifyErrors(validateValues.errors)
 
     if (!isValidConfiguration || !hasValidValues) {
       log.debug('Saw validation errors: %s', configurationErrors.join(','))
@@ -34,7 +109,7 @@ export const schemaValidator = (log: Logger) => {
 
     return {
       result: isValidConfiguration && hasValidValues,
-      errors: configurationErrors.concat(valueErrors),
+      errors: [].concat(validationValueErrors ?? [], validationErrors ?? []),
     }
   }
 
@@ -44,13 +119,16 @@ export const schemaValidator = (log: Logger) => {
       (errors, file) =>
         templates.some(t => new RegExp(file.source).test(t))
           ? errors
-          : errors.add(`'${file.source}' was not found in the templates`),
+          : errors.add(`\`${file.source}\` was not found in the templates`),
       new Set<string>(),
     )
 
     return {
       result: errors.size === 0,
-      errors: Array.from(errors),
+      errors: Array.from(errors).map((e) => ({
+        message: e,
+        line: undefined
+      })),
     }
   }
 

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -1,5 +1,11 @@
 /* eslint-disable no-console */
-import { ConfigurationValues, CSTRepresentation, RepositoryConfiguration, TemplateConfig, TemplateValidation } from './types'
+import {
+  ConfigurationValues,
+  CSTRepresentation,
+  RepositoryConfiguration,
+  TemplateConfig,
+  TemplateValidation,
+} from './types'
 import Ajv, { ErrorObject } from 'ajv'
 import templateSchema from './template-schema.json'
 import { Logger } from 'probot'
@@ -11,10 +17,9 @@ import { Document, SourceToken } from 'yaml/dist/parse/cst'
 const ajv = new Ajv({ allowUnionTypes: true, allErrors: true })
 const validateConfiguration = ajv.compile<RepositoryConfiguration>(templateSchema)
 
-
 const getLineFromOffset = (lines: number[], offset: number): number => {
   for (let index = 1; index < lines.length; index++) {
-    const newLineOffset = lines[index];
+    const newLineOffset = lines[index]
     if (newLineOffset > offset) {
       return index
     }
@@ -25,11 +30,9 @@ const getLineFromOffset = (lines: number[], offset: number): number => {
 const getLineFromInstancePath = (instancePath: string, cst: CSTRepresentation): number | undefined => {
   const pathItems = instancePath.split('/').slice(1)
 
-
   const getLineFromDoc = (doc: Document) => {
     let line = undefined
     CST.visit(doc, (item, path) => {
-
       const currentPathValue = pathItems[path.length - 1]
       const num = Number(currentPathValue)
       // If path step is a number
@@ -84,20 +87,15 @@ export const schemaValidator = (log: Logger) => {
       })
       ?.filter(error => error !== '') ?? []
 
-  const validateTemplateConfiguration = (
-    configuration: TemplateConfig,
-    valuesSchema?: string,
-  ): TemplateValidation => {
+  const validateTemplateConfiguration = (configuration: TemplateConfig, valuesSchema?: string): TemplateValidation => {
     const validateValues = ajv.compile<ConfigurationValues>(JSON.parse(valuesSchema ?? '{}'))
     const isValidConfiguration = validateConfiguration(configuration?.repositoryConfiguration)
     const hasValidValues = validateValues(configuration?.repositoryConfiguration?.values)
 
-    const validationErrors = validateConfiguration.errors?.map(e => (
-      {
-        message: e.message,
-        line: getLineFromInstancePath(e.instancePath, configuration.cstYamlRepresentation)
-      }
-    ))
+    const validationErrors = validateConfiguration.errors?.map(e => ({
+      message: e.message,
+      line: getLineFromInstancePath(e.instancePath, configuration.cstYamlRepresentation),
+    }))
 
     const validationValueErrors = validateValues.errors?.map(e => ({ message: e.message, line: undefined }))
 
@@ -125,9 +123,9 @@ export const schemaValidator = (log: Logger) => {
 
     return {
       result: errors.size === 0,
-      errors: Array.from(errors).map((e) => ({
+      errors: Array.from(errors).map(e => ({
         message: e,
-        line: undefined
+        line: undefined,
       })),
     }
   }

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -111,8 +111,9 @@ export const schemaValidator = (log: Logger) => {
       line: getLineFromInstancePath(e.instancePath, configuration.cstYamlRepresentation),
     }))
 
-    const validationValueErrors = (validateValues.errors ?? [])
-      .map(e => ({ message: e.message, line: undefined } as ValidationError))
+    const validationValueErrors = (validateValues.errors ?? []).map(
+      e => ({ message: e.message, line: undefined } as ValidationError),
+    )
 
     if (!isValidConfiguration || !hasValidValues) {
       log.debug('Saw validation errors: %s', prettifyErrors(validateConfiguration.errors).join(','))

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -37,6 +37,9 @@ const getLineFromOffset = (lines: number[], offset: number): number => {
 const getLineFromInstancePath = (instancePath: string, cst: CSTRepresentation): number | undefined => {
   const pathItems = instancePath.split('/').slice(1)
 
+  // If there is no path no line can be found
+  if (pathItems.length === 0) return
+
   const getLineFromDoc = (doc: Document) => {
     let line = undefined
     CST.visit(doc, (item, path) => {
@@ -47,6 +50,8 @@ const getLineFromInstancePath = (instancePath: string, cst: CSTRepresentation): 
         if (!CST.isScalar(item.value)) return
 
         const key = item.key as SourceToken
+
+        if (!key) return
 
         // If note key is not the current path value skip this node and its childs and go to next sibling
         if (key.source !== currentPathValue) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { ProbotOctokit } from 'probot'
+import { Token } from 'yaml/dist/parse/cst'
 
 export interface PathConfiguration {
   source: string
@@ -6,6 +7,16 @@ export interface PathConfiguration {
 }
 
 export type ConfigurationValues = { [key: string]: string | undefined }
+
+export interface TemplateConfig {
+  repositoryConfiguration: RepositoryConfiguration | undefined,
+  cstYamlRepresentation: CSTRepresentation
+}
+
+export interface CSTRepresentation {
+  tokens: Token[],
+  lines: number[]
+}
 
 export interface RepositoryConfiguration {
   version: string
@@ -57,9 +68,14 @@ export type UpdateCheckInput = CreateCheckInput & {
   checkRunId: number
 }
 
+export interface ValidationError {
+  message: string | undefined,
+  line: number | undefined
+}
+
 export interface TemplateValidation {
   result: boolean
-  errors: string[]
+  errors: ValidationError[]
 }
 
 export type OctokitInstance = InstanceType<typeof ProbotOctokit>

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,12 @@ export interface PathConfiguration {
 export type ConfigurationValues = { [key: string]: string | undefined }
 
 export interface TemplateConfig {
-  repositoryConfiguration: RepositoryConfiguration | undefined,
+  repositoryConfiguration: RepositoryConfiguration | undefined
   cstYamlRepresentation: CSTRepresentation
 }
 
 export interface CSTRepresentation {
-  tokens: Token[],
+  tokens: Token[]
   lines: number[]
 }
 
@@ -69,7 +69,7 @@ export type UpdateCheckInput = CreateCheckInput & {
 }
 
 export interface ValidationError {
-  message: string | undefined,
+  message: string | undefined
   line: number | undefined
 }
 

--- a/test/configuration.test.ts
+++ b/test/configuration.test.ts
@@ -37,7 +37,7 @@ values:
 
     const result = await determineConfigurationChanges('', repositoryDetails, '')
 
-    expect(result).toEqual(expected)
+    expect(result.repositoryConfiguration).toEqual(expected)
   })
 
   test('combines configurations as expected', () => {

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -34,7 +34,8 @@ describe('Pull Request reviews', () => {
       const expectedMainBody = `🤖 It looks like your template changes are invalid.
 
 There were the following errors:
-        - hello
+        - \`hello\`
+
 Check the PR comments for any additional errors.`
 
       const result = await requestPullRequestChanges(testRepository, testPullRequestNumber, '.github/templates.yaml', [
@@ -51,7 +52,7 @@ Check the PR comments for any additional errors.`
         comments: [
           {
             path: '.github/templates.yaml',
-            body: 'world',
+            body: '`world`',
             line: 13,
           },
         ],

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -31,23 +31,36 @@ describe('Pull Request reviews', () => {
     })
 
     test('can request changes on PRs', async () => {
-      const expectedBody = `
-🤖 It looks like your changes are invalid. 
+      const expectedMainBody = `🤖 It looks like your template changes are invalid.
 
-Validating the changes in this PR resulted in the following errors: 
+There were the following errors:
+        - hello
+Check the PR comments for any additional error.`
 
-- hello
-- world
-`
-      const result = await requestPullRequestChanges(testRepository, testPullRequestNumber, ['hello', 'world'])
+      const result = await requestPullRequestChanges(
+        testRepository,
+        testPullRequestNumber,
+        '.github/templates.yaml',
+        [
+          { message: 'hello', line: undefined },
+          { message: 'world', line: 13 }
+        ])
 
       expect(octokitMock.pulls.createReview).toBeCalledTimes(1)
       expect(octokitMock.pulls.createReview).toHaveBeenCalledWith({
         ...testRepository,
         pull_number: testPullRequestNumber,
         event: 'REQUEST_CHANGES',
-        body: expectedBody,
+        body: expectedMainBody,
+        comments: [
+          {
+            path: '.github/templates.yaml',
+            body: 'world',
+            line: 13
+          }
+        ]
       })
+
       expect(result).toEqual('reviewId')
     })
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -35,7 +35,7 @@ describe('Pull Request reviews', () => {
 
 There were the following errors:
         - hello
-Check the PR comments for any additional error.`
+Check the PR comments for any additional errors.`
 
       const result = await requestPullRequestChanges(testRepository, testPullRequestNumber, '.github/templates.yaml', [
         { message: 'hello', line: undefined },

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -37,14 +37,10 @@ There were the following errors:
         - hello
 Check the PR comments for any additional error.`
 
-      const result = await requestPullRequestChanges(
-        testRepository,
-        testPullRequestNumber,
-        '.github/templates.yaml',
-        [
-          { message: 'hello', line: undefined },
-          { message: 'world', line: 13 }
-        ])
+      const result = await requestPullRequestChanges(testRepository, testPullRequestNumber, '.github/templates.yaml', [
+        { message: 'hello', line: undefined },
+        { message: 'world', line: 13 },
+      ])
 
       expect(octokitMock.pulls.createReview).toBeCalledTimes(1)
       expect(octokitMock.pulls.createReview).toHaveBeenCalledWith({
@@ -56,9 +52,9 @@ Check the PR comments for any additional error.`
           {
             path: '.github/templates.yaml',
             body: 'world',
-            line: 13
-          }
-        ]
+            line: 13,
+          },
+        ],
       })
 
       expect(result).toEqual('reviewId')

--- a/test/schema-validator.test.ts
+++ b/test/schema-validator.test.ts
@@ -13,7 +13,7 @@ const getCst = (content: string): CSTRepresentation => {
 
   return {
     tokens: tokens,
-    lines: lineCounter.lineStarts
+    lines: lineCounter.lineStarts,
   }
 }
 
@@ -25,8 +25,8 @@ describe('Schema Tests', () => {
       repositoryConfiguration: parse('DFds'),
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
 
     const { result, errors } = validateTemplateConfiguration(input)
@@ -39,8 +39,8 @@ describe('Schema Tests', () => {
       repositoryConfiguration: undefined,
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     })
     expect(result).toBeFalsy()
     expect(errors?.length).not.toEqual(0)
@@ -63,8 +63,8 @@ describe('Schema Tests', () => {
       repositoryConfiguration: input,
       cstYamlRepresentation: {
         tokens: [],
-        lines: []
-      }
+        lines: [],
+      },
     })
     expect(result).toBeFalsy()
     expect(errors?.length).not.toEqual(0)
@@ -87,8 +87,8 @@ describe('Schema Tests', () => {
 
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeTruthy()
@@ -112,8 +112,8 @@ describe('Schema Tests', () => {
 
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeTruthy()
@@ -135,7 +135,7 @@ describe('Schema Tests', () => {
     const configuration = {
       repositoryConfiguration: parse(content),
 
-      cstYamlRepresentation: getCst(content)
+      cstYamlRepresentation: getCst(content),
     }
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeFalsy()
@@ -158,7 +158,7 @@ describe('Schema Tests', () => {
     const configuration = {
       repositoryConfiguration: parse(content),
 
-      cstYamlRepresentation: getCst(content)
+      cstYamlRepresentation: getCst(content),
     }
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeFalsy()
@@ -180,7 +180,7 @@ describe('Schema Tests', () => {
     const configuration = {
       repositoryConfiguration: parse(content),
 
-      cstYamlRepresentation: getCst(content)
+      cstYamlRepresentation: getCst(content),
     }
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeFalsy()
@@ -202,8 +202,8 @@ describe('Schema Tests', () => {
 
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
 
     const valuesSchema = `{
@@ -235,8 +235,8 @@ describe('Schema Tests', () => {
 
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
 
     const valuesSchema = `{
@@ -288,8 +288,8 @@ describe('Schema Tests', () => {
       repositoryConfiguration: parse('version: v10.7.0'),
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
 
     const { result, errors } = validateTemplateConfiguration(configuration)
@@ -302,8 +302,8 @@ describe('Schema Tests', () => {
       repositoryConfiguration: parse('version: bla'),
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
 
     const { result, errors } = validateTemplateConfiguration(configuration)
@@ -316,8 +316,8 @@ describe('Schema Tests', () => {
       repositoryConfiguration: parse(''),
       cstYamlRepresentation: {
         lines: [],
-        tokens: []
-      }
+        tokens: [],
+      },
     }
 
     const { result, errors } = validateTemplateConfiguration(configuration)

--- a/test/schema-validator.test.ts
+++ b/test/schema-validator.test.ts
@@ -1,21 +1,47 @@
 import { Logger } from 'probot'
-import { parse } from 'yaml'
+import { LineCounter, parse, Parser } from 'yaml'
 import { schemaValidator } from '../src/schema-validator'
+import { CSTRepresentation } from '../src/types'
 
 const log = { info: () => ({}), error: () => ({}), debug: () => ({}) } as unknown as Logger
+
+const getCst = (content: string): CSTRepresentation => {
+  const lineCounter = new LineCounter()
+
+  const cst = new Parser(lineCounter.addNewLine).parse(content)
+  const tokens = Array.from(cst)
+
+  return {
+    tokens: tokens,
+    lines: lineCounter.lineStarts
+  }
+}
 
 describe('Schema Tests', () => {
   const { generateSchema, validateTemplateConfiguration, validateFiles } = schemaValidator(log)
 
   test('returns false for an invalid input', async () => {
-    const input = parse('DFds')
+    const input = {
+      repositoryConfiguration: parse('DFds'),
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
+
     const { result, errors } = validateTemplateConfiguration(input)
     expect(result).toBeFalsy()
     expect(errors?.length).not.toEqual(0)
   })
 
   test('returns false for undefined input', async () => {
-    const { result, errors } = validateTemplateConfiguration(undefined)
+    const { result, errors } = validateTemplateConfiguration({
+      repositoryConfiguration: undefined,
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    })
     expect(result).toBeFalsy()
     expect(errors?.length).not.toEqual(0)
   })
@@ -33,13 +59,20 @@ describe('Schema Tests', () => {
           - source: null
             destination: path/to/template-destination/filename.yaml
         `)
-    const { result, errors } = validateTemplateConfiguration(input)
+    const { result, errors } = validateTemplateConfiguration({
+      repositoryConfiguration: input,
+      cstYamlRepresentation: {
+        tokens: [],
+        lines: []
+      }
+    })
     expect(result).toBeFalsy()
     expect(errors?.length).not.toEqual(0)
   })
 
   test('returns true for a null value on a nullable type', async () => {
-    const input = parse(`
+    const configuration = {
+      repositoryConfiguration: parse(`
         # The template version to use (optional).
         version: v10.7.0
         
@@ -50,14 +83,21 @@ describe('Schema Tests', () => {
         files:           
           - source: path/to/template/filename.yaml
             destination: path/to/template-destination/filename.yaml
-        `)
-    const { result, errors } = validateTemplateConfiguration(input)
+            `),
+
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
+    const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeTruthy()
     expect(errors?.length).toEqual(0)
   })
 
   test('returns true for a valid schema', async () => {
-    const input = parse(`
+    const configuration = {
+      repositoryConfiguration: parse(`
         # The template version to use (optional).
         version: v10.7.0
         
@@ -68,14 +108,89 @@ describe('Schema Tests', () => {
         files:           
           - source: path/to/template/filename.yaml
             destination: path/to/template-destination/filename.yaml
-        `)
-    const { result, errors } = validateTemplateConfiguration(input)
+        `),
+
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
+    const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeTruthy()
     expect(errors?.length).toEqual(0)
   })
 
+  test('returns false and error with line when property is wrong', async () => {
+    const content = `# The template version to use (optional).
+    version: v10.7.0
+    
+    # Whether to merge template changes automatically (optional).
+    automerge: notABoolean
+    
+    # Templates to add to the repository (optional).
+    files:           
+      - source: path/to/template/filename.yaml
+        destination: path/to/template-destination/filename.yaml
+    `
+    const configuration = {
+      repositoryConfiguration: parse(content),
+
+      cstYamlRepresentation: getCst(content)
+    }
+    const { result, errors } = validateTemplateConfiguration(configuration)
+    expect(result).toBeFalsy()
+    expect(errors?.length).toEqual(1)
+    expect(errors[0].line).toBe(5)
+  })
+
+  test('returns false and error with line when map property is wrong', async () => {
+    const content = `# The template version to use (optional).
+    version: v10.7.0
+    
+    # Whether to merge template changes automatically (optional).
+    automerge: true
+    
+    # Templates to add to the repository (optional).
+    files:           
+      - source: 2
+        destination: path/to/template-destination/filename.yaml
+    `
+    const configuration = {
+      repositoryConfiguration: parse(content),
+
+      cstYamlRepresentation: getCst(content)
+    }
+    const { result, errors } = validateTemplateConfiguration(configuration)
+    expect(result).toBeFalsy()
+    expect(errors?.length).toEqual(1)
+    expect(errors[0].line).toBe(9)
+  })
+
+  test('returns false and error with line when array property is wrong', async () => {
+    const content = `# The template version to use (optional).
+    version: v10.7.0
+    
+    # Whether to merge template changes automatically (optional).
+    automerge: true
+    
+    # Templates to add to the repository (optional).
+    files:           
+      - 2
+    `
+    const configuration = {
+      repositoryConfiguration: parse(content),
+
+      cstYamlRepresentation: getCst(content)
+    }
+    const { result, errors } = validateTemplateConfiguration(configuration)
+    expect(result).toBeFalsy()
+    expect(errors?.length).toEqual(1)
+    expect(errors[0].line).toBe(9)
+  })
+
   test('validates valid values', async () => {
-    const configuration = parse(`
+    const configuration = {
+      repositoryConfiguration: parse(`
         version: v10.7.0
         automerge: true
         files:           
@@ -83,7 +198,13 @@ describe('Schema Tests', () => {
             destination: path/to/template-destination/filename.yaml
         values: 
           jdkVersion: 17
-        `)
+        `),
+
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
 
     const valuesSchema = `{
       "$schema": "http://json-schema.org/draft-07/schema",
@@ -100,8 +221,9 @@ describe('Schema Tests', () => {
     expect(errors?.length).toEqual(0)
   })
 
-  test('invalidates a invalid values', async () => {
-    const configuration = parse(`
+  test('invalidates invalid values', async () => {
+    const configuration = {
+      repositoryConfiguration: parse(`
         version: v10.7.0
         automerge: true
         files:           
@@ -109,7 +231,13 @@ describe('Schema Tests', () => {
             destination: path/to/template-destination/filename.yaml
         values: 
           jdkVersion: true
-        `)
+        `),
+
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
 
     const valuesSchema = `{
       "$schema": "http://json-schema.org/draft-07/schema",
@@ -156,7 +284,13 @@ describe('Schema Tests', () => {
   })
 
   test('validates valid versions', async () => {
-    const configuration = parse('version: v10.7.0')
+    const configuration = {
+      repositoryConfiguration: parse('version: v10.7.0'),
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
 
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeTruthy()
@@ -164,15 +298,27 @@ describe('Schema Tests', () => {
   })
 
   test('invalidates invalid versions', async () => {
-    const configuration = parse('version: bla')
+    const configuration = {
+      repositoryConfiguration: parse('version: bla'),
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
 
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeFalsy()
     expect(errors?.length).toEqual(1)
   })
 
-  test('invalidates invalid versions', async () => {
-    const configuration = parse('')
+  test('invalidates empty config', async () => {
+    const configuration = {
+      repositoryConfiguration: parse(''),
+      cstYamlRepresentation: {
+        lines: [],
+        tokens: []
+      }
+    }
 
     const { result, errors } = validateTemplateConfiguration(configuration)
     expect(result).toBeFalsy()

--- a/test/schema-validator.test.ts
+++ b/test/schema-validator.test.ts
@@ -166,6 +166,30 @@ describe('Schema Tests', () => {
     expect(errors[0].line).toBe(9)
   })
 
+  test('returns false and multiple errors with annotated line when map property is wrong', async () => {
+    const content = `# The template version to use (optional).
+    version: v10.7.0
+    
+    # Whether to merge template changes automatically (optional).
+    automerge: notAboolean
+    
+    # Templates to add to the repository (optional).
+    files:           
+      - source: 2
+        destination: path/to/template-destination/filename.yaml
+    `
+    const configuration = {
+      repositoryConfiguration: parse(content),
+
+      cstYamlRepresentation: getCst(content),
+    }
+    const { result, errors } = validateTemplateConfiguration(configuration)
+    expect(result).toBeFalsy()
+    expect(errors?.length).toEqual(2)
+    expect(errors[0].line).toBe(5)
+    expect(errors[1].line).toBe(9)
+  })
+
   test('returns false and error with line when array property is wrong', async () => {
     const content = `# The template version to use (optional).
     version: v10.7.0
@@ -252,6 +276,7 @@ describe('Schema Tests', () => {
     const { result, errors } = validateTemplateConfiguration(configuration, valuesSchema)
     expect(result).toBeFalsy()
     expect(errors?.length).toEqual(1)
+    expect(errors[0].line).toBeUndefined()
   })
 
   test('generates JSON schema from values', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,7 +1095,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@swc/cli@^0.1.57":
+"@swc/cli@0.1.57":
   version "0.1.57"
   resolved "https://registry.yarnpkg.com/@swc/cli/-/cli-0.1.57.tgz#a9c424de5a217ec20a4b7c2c0e5c343980537e83"
   integrity sha512-HxM8TqYHhAg+zp7+RdTU69bnkl4MWdt1ygyp6BDIPjTiaJVH6Dizn2ezbgDS8mnFZI1FyhKvxU/bbaUs8XhzQg==
@@ -1182,7 +1182,7 @@
   resolved "https://registry.yarnpkg.com/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.10.tgz#59ee9a8e250ffd431295cb8e142462413f04cd62"
   integrity sha512-40yeeov6XcJHm99anMeEn/NwhDcoM2fhBQHWRVZfCa43QC45AUjJ3kWrD76U6MPGnGy7MsCOXdFyu1mJOAHKEw==
 
-"@swc/core@^1.3.10":
+"@swc/core@1.3.10":
   version "1.3.10"
   resolved "https://registry.yarnpkg.com/@swc/core/-/core-1.3.10.tgz#32f4d5ac4c7f09e90f421791b0d325d86c46bbbd"
   integrity sha512-A5YjYFa45ThHOwftKqIQKNbukxJGTsdBQAqoTr+QD1/L6jbRg3xxhU5UDyVdUIULz40PH6YQiulyUVbyrjl1Iw==
@@ -1374,7 +1374,7 @@
   resolved "https://registry.yarnpkg.com/@types/mustache/-/mustache-4.2.1.tgz#724a2fca5763117dee626aa4ca3e3f6e546e7434"
   integrity sha512-gFAlWL9Ik21nJioqjlGCnNYbf9zHi0sVbaZ/1hQEBcCEuxfLJDvz4bVJSV6v6CUaoLOz0XEIoP7mSrhJ6o237w==
 
-"@types/node@*":
+"@types/node@*", "@types/node@>=13.7.0":
   version "18.11.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.5.tgz#1bc94cf2f9ab5fe33353bc7c79c797dcc5325bef"
   integrity sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==
@@ -1383,11 +1383,6 @@
   version "18.8.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.8.2.tgz#17d42c6322d917764dd3d2d3a10d7884925de067"
   integrity sha512-cRMwIgdDN43GO4xMWAfJAecYn8wV4JbsOGHNfNUIDiuYkUYAR5ec4Rj7IO2SAhFPEfpPtLtUTbbny/TCT7aDwA==
-
-"@types/node@>=13.7.0":
-  version "18.11.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.5.tgz#1bc94cf2f9ab5fe33353bc7c79c797dcc5325bef"
-  integrity sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==
 
 "@types/pino-http@^5.0.6":
   version "5.8.1"
@@ -2133,7 +2128,7 @@ dateformat@^4.5.1:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-dd-trace@^3.6.0:
+dd-trace@3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/dd-trace/-/dd-trace-3.6.0.tgz#c2701f13ff407ed139a5463b8decd968e3d0909a"
   integrity sha512-r7D93QmYjacAeb3oozChsAt84QePNI52qq05Ls8DwCjtDzlvFwASw9qE5EwPS3yfgspxDxmOAQVeqlF19QvZzA==


### PR DESCRIPTION
[Linear ticket](https://linear.app/pleo/issue/DX-721/add-errors-on-pr-comments)

This PR adds a comment on each error on the specific line where it failed. In order to do so, a CST ([Concrete Syntax Tree](https://en.wikipedia.org/wiki/Parse_tree)) is used as per https://eemeli.org/yaml/#parser, so all the content is preserved pristine. 

Once the validation is performed a list of errors with an instance path is received. For each error, the path is matched against the tree representation by performing a depth search. When the node is found, it is compared its offset against the line offset to find the particular line.

Example:

<img width="820" alt="Screenshot 2022-11-09 at 11 20 57" src="https://user-images.githubusercontent.com/103436398/200817291-a8aec51f-4a74-4974-89ec-7147f232fc01.png">



