### PR TITLE
Simplify code and fix createTreeChanges

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -49,19 +49,20 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
     }
   }
 
-  const createTreeWithChanges = async (templates: Template[], repository: RepositoryDetails, base_tree: string) => {
+  const createTreeWithChanges = async (templates: Template[], repository: RepositoryDetails, baseTree: string) => {
     log.debug('Creating git tree with modified templates.')
+    const templateTree = templates.map(template => ({
+      path: template.destinationPath,
+      mode: '100644' as const,
+      type: 'blob' as const,
+      content: template.contents,
+    }))
     const {
       data: { sha: createdTreeSha },
     } = await octokit.git.createTree({
       ...repository,
-      base_tree: base_tree,
-      tree: templates.map(template => ({
-        path: template.destinationPath,
-        mode: '100644',
-        type: 'blob',
-        content: template.contents,
-      })),
+      base_tree: baseTree,
+      tree: templateTree,
     })
     log.debug("Created git tree with SHA '%s'.", createdTreeSha)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface RepositoryConfiguration {
 export interface RepositoryDetails {
   owner: string
   repo: string
-  defaultBranch?: string
+  defaultBranch: string
 }
 
 export interface ExtractedContent {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -158,6 +158,7 @@ describe('Probot Tests', () => {
         repository: {
           owner: { login: 'pleo-oss' },
           name: 'test',
+          default_branch: 'main',
         },
       },
     }
@@ -201,6 +202,7 @@ describe('Probot Tests', () => {
         repository: {
           owner: { login: 'pleo-oss' },
           name: 'test',
+          default_branch: 'baseBranch',
         },
       },
     }


### PR DESCRIPTION
This changes the way createTree changes work. A bug has been reported that after changing a variable, the resulting PR didn't contain any change. After debugging the rendering was done fine but the resulting changes didn't contain any file changed. Now it applies the changes to a base commit, and simplifies the code resulting in less calls to GitHub API which were not needed

[Linear ticket](https://linear.app/pleo/issue/DX-726/values-updates-doesnt-trigger-template-generation)