### PR TITLE
Move comments to checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "format": "prettier --write src/**/*.ts test/**/*.ts && eslint --fix --ext .ts src && eslint --fix --ext .ts test"
   },
   "dependencies": {
-    "@types/ajv-merge-patch": "^4.1.2",
     "ajv": "8.11.0",
     "ajv-merge-patch": "^5.0.1",
     "codeowners-utils": "1.0.2",
@@ -38,6 +37,7 @@
     "@swc/cli": "0.1.57",
     "@swc/core": "1.3.10",
     "@swc/jest": "0.2.23",
+    "@types/ajv-merge-patch": "^4.1.2",
     "@types/jest": "29.1.2",
     "@types/mustache": "4.2.1",
     "@types/node": "18.8.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "format": "prettier --write src/**/*.ts test/**/*.ts && eslint --fix --ext .ts src && eslint --fix --ext .ts test"
   },
   "dependencies": {
+    "@types/ajv-merge-patch": "^4.1.2",
     "ajv": "8.11.0",
     "ajv-merge-patch": "^5.0.1",
     "codeowners-utils": "1.0.2",
@@ -37,7 +38,6 @@
     "@swc/cli": "0.1.57",
     "@swc/core": "1.3.10",
     "@swc/jest": "0.2.23",
-    "@types/ajv-merge-patch": "^4.1.2",
     "@types/jest": "29.1.2",
     "@types/mustache": "4.2.1",
     "@types/node": "18.8.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -120,14 +120,14 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
   const onlyChangesConfiguration = filesChanged.length === 1 && filesChanged[0] === configFileName
 
   if (errors.length > 0) {
-    const changeRequestId = await requestPullRequestChanges(repository, prNumber, configFileName, errors)
+    const changeRequestId = await requestPullRequestChanges(repository, prNumber, checkId)
     log.debug(`Requested changes for PR #%d in %s.`, prNumber, changeRequestId)
   } else if (onlyChangesConfiguration) {
     const approvedReviewId = await approvePullRequestChanges(repository, prNumber)
     log.debug(`Approved PR #%d in %s.`, prNumber, approvedReviewId)
   }
 
-  const checkConclusion = await resolveCheckRun({ ...checkInput, conclusion: conclusion(errors), checkRunId: checkId })
+  const checkConclusion = await resolveCheckRun({ ...checkInput, conclusion: conclusion(errors), checkRunId: checkId, errors }, configFileName)
 
   log.info(`Validated configuration changes in #%d with conclusion: %s.`, prNumber, checkConclusion)
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -127,7 +127,10 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
     log.debug(`Approved PR #%d in %s.`, prNumber, approvedReviewId)
   }
 
-  const checkConclusion = await resolveCheckRun({ ...checkInput, conclusion: conclusion(errors), checkRunId: checkId, errors }, configFileName)
+  const checkConclusion = await resolveCheckRun(
+    { ...checkInput, conclusion: conclusion(errors), checkRunId: checkId, errors },
+    configFileName,
+  )
 
   log.info(`Validated configuration changes in #%d with conclusion: %s.`, prNumber, checkConclusion)
 }

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -31,7 +31,6 @@ export const checks = (log: Logger, octokit: Pick<OctokitInstance, 'checks'>) =>
       const errorsWithoutLine = input.errors.filter(e => !e.line)
       const errorsWithLine = input.errors.filter(e => e.line)
 
-
       log.debug('Updating check run %d.', checkRunId)
       const {
         data: { conclusion: result },
@@ -45,7 +44,7 @@ export const checks = (log: Logger, octokit: Pick<OctokitInstance, 'checks'>) =>
         conclusion,
         output: {
           title: 'Schema validation',
-          summary: "There has been some errors during the validation",
+          summary: 'There has been some errors during the validation',
           text: `The following errors don't have a line associated: 
             ${errorsWithoutLine.map(e => `- \`${e.message}\``).join('\n')}`,
           annotations: errorsWithLine.map(err => ({
@@ -53,8 +52,8 @@ export const checks = (log: Logger, octokit: Pick<OctokitInstance, 'checks'>) =>
             start_line: err.line,
             end_line: err.line,
             annotation_level: 'failure',
-            message: err.message
-          }))
+            message: err.message,
+          })),
         },
       })
       log.debug('Updated check run %d with conclusion %s.', checkRunId, result)
@@ -79,8 +78,6 @@ export const checks = (log: Logger, octokit: Pick<OctokitInstance, 'checks'>) =>
       log.debug('Updated check run %d with conclusion %s.', checkRunId, result)
       return result
     }
-
-
   }
 
   return {

--- a/src/git.ts
+++ b/src/git.ts
@@ -268,29 +268,10 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
   const requestPullRequestChanges = async (
     repository: RepositoryDetails,
     pullRequestNumber: number,
-    configFileName: string,
-    errors: ValidationError[],
+    checkId: number
   ) => {
-    const errorsWithoutLine = errors.filter(e => !e.line)
+    const body = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}/checks?check_run_id=${checkId})`
 
-    const comments = errors
-      .filter(e => e.line)
-      .map(e => ({
-        path: configFileName,
-        body: `\`${e.message}\`` ?? '',
-        line: e.line,
-      }))
-
-    let body = `🤖 It looks like your template changes are invalid.\n\n`
-
-    if (errorsWithoutLine.length > 0) {
-      body = body.concat(`There were the following errors:
-        ${errorsWithoutLine.map(e => `- \`${e.message}\``).join('\n')}`)
-    }
-
-    if (comments.length > 0) {
-      body = body.concat('\n\nCheck the PR comments for any additional errors.')
-    }
 
     log.debug('Creating change request review on PR #%d.', pullRequestNumber)
     const {
@@ -300,7 +281,6 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
       pull_number: pullRequestNumber,
       event: 'REQUEST_CHANGES',
       body,
-      comments,
     })
 
     log.debug("Created change request review '%d'.", id)

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,5 @@
 import { Logger } from 'probot'
-import { OctokitInstance, PRDetails, RepositoryDetails, Template, ValidationError } from './types'
+import { OctokitInstance, PRDetails, RepositoryDetails, Template } from './types'
 
 const baseBranchName = 'centralized-templates'
 const reducedBranchName = `heads/${baseBranchName}`

--- a/src/git.ts
+++ b/src/git.ts
@@ -268,10 +268,9 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
   const requestPullRequestChanges = async (
     repository: RepositoryDetails,
     pullRequestNumber: number,
-    checkId: number
+    checkId: number,
   ) => {
     const body = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}/checks?check_run_id=${checkId})`
-
 
     log.debug('Creating change request review on PR #%d.', pullRequestNumber)
     const {

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {
   ConfigurationValues,
   CSTRepresentation,
@@ -15,9 +14,10 @@ import { CST } from 'yaml'
 
 import { Document, SourceToken } from 'yaml/dist/parse/cst'
 import ajvMergePatch from 'ajv-merge-patch'
+import { default as AjvPatch } from "ajv-merge-patch/node_modules/ajv/dist/ajv";
 
 const ajv = new Ajv({ allowUnionTypes: true, allErrors: true })
-ajvMergePatch(ajv)
+ajvMergePatch(ajv as unknown as AjvPatch)
 
 const getLineFromOffset = (lines: number[], offset: number): number => {
   for (let index = 1; index < lines.length; index++) {

--- a/src/schema-validator.ts
+++ b/src/schema-validator.ts
@@ -14,7 +14,7 @@ import { CST } from 'yaml'
 
 import { Document, SourceToken } from 'yaml/dist/parse/cst'
 import ajvMergePatch from 'ajv-merge-patch'
-import { default as AjvPatch } from "ajv-merge-patch/node_modules/ajv/dist/ajv";
+import { default as AjvPatch } from 'ajv-merge-patch/node_modules/ajv/dist/ajv'
 
 const ajv = new Ajv({ allowUnionTypes: true, allErrors: true })
 ajvMergePatch(ajv as unknown as AjvPatch)

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,7 @@ export interface CreateCheckInput {
 export type UpdateCheckInput = CreateCheckInput & {
   conclusion: string
   checkRunId: number
+  errors: ValidationError[]
 }
 
 export interface ValidationError {

--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -99,6 +99,7 @@ describe('Github api calls', () => {
       sha: testSha,
       conclusion: 'failure',
       checkRunId: 98,
+      errors: [],
     }
 
     beforeEach(() => {
@@ -129,9 +130,15 @@ describe('Github api calls', () => {
         sha: testSha,
         conclusion: 'failure',
         checkRunId: 98,
+        errors: [
+          {
+            message: "There is an error",
+            line: 1
+          }
+        ]
       }
 
-      await resolveCheckRun(testInput)
+      await resolveCheckRun(testInput, '.github/templates.yaml')
 
       expect(octokitMock.checks.update).toBeCalledTimes(1)
       expect(octokitMock.checks.update).not.toHaveBeenCalledWith({
@@ -143,6 +150,16 @@ describe('Github api calls', () => {
         output: {
           title: 'Schema validation',
           summary: testInput.conclusion,
+          annotations: [
+            {
+
+              path: '.github/templates.yaml',
+              start_line: 1,
+              end_line: 1,
+              annotation_level: 'failure',
+              message: "There is an error"
+            }
+          ]
         },
       })
     })
@@ -153,6 +170,7 @@ describe('Github api calls', () => {
         sha: testSha,
         conclusion: 'failure',
         checkRunId: 98,
+        errors: [],
       }
 
       const { resolveCheckRun } = checks(log, throwingOctokit)

--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -132,10 +132,10 @@ describe('Github api calls', () => {
         checkRunId: 98,
         errors: [
           {
-            message: "There is an error",
-            line: 1
-          }
-        ]
+            message: 'There is an error',
+            line: 1,
+          },
+        ],
       }
 
       await resolveCheckRun(testInput, '.github/templates.yaml')
@@ -152,14 +152,13 @@ describe('Github api calls', () => {
           summary: testInput.conclusion,
           annotations: [
             {
-
               path: '.github/templates.yaml',
               start_line: 1,
               end_line: 1,
               annotation_level: 'failure',
-              message: "There is an error"
-            }
-          ]
+              message: 'There is an error',
+            },
+          ],
         },
       })
     })

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -93,17 +93,10 @@ describe('Pull Request reviews', () => {
     })
 
     test('can request changes on PRs', async () => {
-      const expectedMainBody = `🤖 It looks like your template changes are invalid.
+      const checkId = 123
+      const expectedMainBody = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${testRepository.owner}/${testRepository.repo}/pull/${testPullRequestNumber}/checks?check_run_id=${checkId})`
 
-There were the following errors:
-        - \`hello\`
-
-Check the PR comments for any additional errors.`
-
-      const result = await requestPullRequestChanges(testRepository, testPullRequestNumber, '.github/templates.yaml', [
-        { message: 'hello', line: undefined },
-        { message: 'world', line: 13 },
-      ])
+      const result = await requestPullRequestChanges(testRepository, testPullRequestNumber, checkId)
 
       expect(octokitMock.pulls.createReview).toBeCalledTimes(1)
       expect(octokitMock.pulls.createReview).toHaveBeenCalledWith({
@@ -111,13 +104,6 @@ Check the PR comments for any additional errors.`
         pull_number: testPullRequestNumber,
         event: 'REQUEST_CHANGES',
         body: expectedMainBody,
-        comments: [
-          {
-            path: '.github/templates.yaml',
-            body: '`world`',
-            line: 13,
-          },
-        ],
       })
 
       expect(result).toEqual('reviewId')


### PR DESCRIPTION
This PR moves the comment from being posted by the bot to being annotated as part of the check. The advantage is that is much more clear to see from which bot the changes come.

Example:

![Screenshot 2022-11-16 at 11 50 55](https://user-images.githubusercontent.com/103436398/202445549-4f5f371b-9b16-41c0-af84-5d8664ace517.png)
![Screenshot 2022-11-16 at 11 51 26](https://user-images.githubusercontent.com/103436398/202445569-8a774a9a-0d3e-4b57-859e-7afd5928e92a.png)
![Screenshot 2022-11-16 at 11 51 34](https://user-images.githubusercontent.com/103436398/202445588-5430c621-96c1-4479-915f-89b01c0a957e.png)
