### PR TITLE
Change start script to inject custom octokit retry options

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "swc src -d lib -s --copy-files",
     "build:run": "yarn build && yarn start",
-    "start": "probot run ./lib/app.js",
+    "start": "node ./lib/start.js",
     "test": "jest",
     "lint": "prettier --check src/**/*.ts test/**/*.ts && eslint --ext .ts src && eslint --ext .ts test",
     "format": "prettier --write src/**/*.ts test/**/*.ts && eslint --fix --ext .ts src && eslint --fix --ext .ts test"
@@ -55,8 +55,5 @@
     "smee-client": "1.2.3",
     "ts-jest": "29.0.3",
     "typescript": "4.8.4"
-  },
-  "engines": {
-    "node": ">= 16.0.0"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -23,11 +23,7 @@ const extractRepositoryInformation = (payload: PushEvent) => {
     },
   } = payload
 
-  return {
-    owner: login,
-    repo: name,
-    defaultBranch: default_branch,
-  }
+  return { owner: login, repo: name, defaultBranch: default_branch }
 }
 
 const extractPullRequestInformation = (payload: PullRequestEvent) => {
@@ -43,7 +39,15 @@ const extractPullRequestInformation = (payload: PullRequestEvent) => {
     },
   } = payload
 
-  return { number, sha, repository: { owner: login, repo: name, defaultBranch: default_branch } }
+  return {
+    number,
+    sha,
+    repository: {
+      owner: login,
+      repo: name,
+      defaultBranch: default_branch,
+    },
+  }
 }
 
 const validateChanges = async (
@@ -108,8 +112,14 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
 
   if (!configFile) return
 
-  const checkInput = { ...repository, sha: sha }
-  const checkId = await createCheckRun({ ...repository, sha: sha })
+  const checkInput = {
+    ...repository,
+    sha: sha,
+  }
+  const checkId = await createCheckRun({
+    ...repository,
+    sha: sha,
+  })
 
   log.debug('Found repository configuration file: %s.', configFile)
 
@@ -128,7 +138,12 @@ const processPullRequest = async (payload: PullRequestEvent, context: Context<'p
   }
 
   const checkConclusion = await resolveCheckRun(
-    { ...checkInput, conclusion: conclusion(errors), checkRunId: checkId, errors },
+    {
+      ...checkInput,
+      conclusion: conclusion(errors),
+      checkRunId: checkId,
+      errors,
+    },
     configFileName,
   )
 
@@ -158,6 +173,7 @@ const processPushEvent = async (payload: PushEvent, context: Context<'push'>) =>
   const parsed = await determineConfigurationChanges(configFileName, repository, payload.after)
 
   if (!parsed.repositoryConfiguration) return
+
   const { configuration: defaultValues } = await getTemplateInformation(parsed.repositoryConfiguration.version)
 
   const combined = combineConfigurations(defaultValues, parsed.repositoryConfiguration)

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,85 @@
+import { Server, Probot, ProbotOctokit } from 'probot'
+import { default as app } from './app'
+import { default as dotenv } from 'dotenv'
+import { Options, ServerOptions } from 'probot/lib/types'
+import { GetLogOptions, getLog } from 'probot/lib/helpers/get-log'
+import { readEnvOptions } from 'probot/lib/bin/read-env-options'
+
+dotenv.config()
+
+const envOptions = readEnvOptions(process?.env)
+
+const {
+  // log options
+  logLevel: level,
+  logFormat,
+  logLevelInString,
+  logMessageKey,
+  sentryDsn,
+
+  // server options
+  host,
+  port,
+  webhookPath,
+  webhookProxy,
+
+  // probot options
+  appId,
+  privateKey,
+  redisConfig,
+  secret,
+  baseUrl,
+} = {
+  ...envOptions,
+}
+
+const logOptions: GetLogOptions = {
+  level,
+  logFormat,
+  logLevelInString,
+  logMessageKey,
+  sentryDsn,
+}
+
+const log = getLog(logOptions)
+
+const probotOptions: Options = {
+  appId,
+  privateKey,
+  redisConfig,
+  secret,
+  baseUrl,
+  log: log.child({ name: 'probot' }),
+  Octokit: ProbotOctokit.defaults({
+    retry: {
+      doNotRetry: [400, 401, 403, 422],
+    },
+  }),
+}
+
+const serverOptions: ServerOptions = {
+  host,
+  port,
+  webhookPath,
+  webhookProxy,
+  log: log.child({ name: 'server' }),
+  Probot: Probot.defaults(probotOptions),
+}
+
+if (!appId || !privateKey) {
+  if (!appId) {
+    throw new Error(
+      'App ID is missing, and is required to run in production mode. ' +
+        'To resolve, ensure the APP_ID environment variable is set.',
+    )
+  } else if (!privateKey) {
+    throw new Error(
+      'Certificate is missing, and is required to run in production mode. ' +
+        'To resolve, ensure either the PRIVATE_KEY or PRIVATE_KEY_PATH environment variable is set and contains a valid certificate',
+    )
+  }
+}
+
+const server = new Server(serverOptions)
+
+server.load(app).then(() => server.start())

--- a/test/checks.test.ts
+++ b/test/checks.test.ts
@@ -3,7 +3,11 @@ import { OctokitInstance } from '../src/types'
 import { Logger } from 'probot'
 
 describe('Github api calls', () => {
-  const log = { info: () => ({}), error: () => ({}), debug: () => ({}) } as unknown as Logger
+  const log = {
+    info: () => ({}),
+    error: () => ({}),
+    debug: () => ({}),
+  } as unknown as Logger
   const octokitMock = {
     checks: {
       create: jest.fn(() => {


### PR DESCRIPTION
This PR changes the start script to use a custom `Server`, this is done so custom retry options can be passed to it. The reason to have custom retry options is because it has been observed that some times call to retrieve files from a pull request event received throws a 404 error, due likely an eventual consistency isue. By default octokit-retrier does not retry 404 errors. 

Related: https://github.com/probot/probot/discussions/1768#discussioncomment-4239894