### PR TITLE
Prefer Either Monad to exception handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ajv-merge-patch": "^5.0.1",
     "codeowners-utils": "1.0.2",
     "dotenv": "16.0.3",
+    "fp-ts": "^2.13.1",
     "genson-js": "0.0.8",
     "jszip": "3.10.1",
     "mustache": "4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2723,6 +2723,11 @@ forwarded@0.2.0:
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
 
+fp-ts@^2.13.1:
+  version "2.13.1"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.13.1.tgz#1bf2b24136cca154846af16752dc29e8fa506f2a"
+  integrity sha512-0eu5ULPS2c/jsa1lGFneEFFEdTbembJv8e4QKXeVJ3lm/5hyve06dlKZrpxmMwJt6rYen7sxmHHK2CLaXvWuWQ==
+
 fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"


### PR DESCRIPTION
This will avoid exception throwing and handling for passing information relating to templates across the application logic, since exceptions shouldn't be used for data passing and application logic.

This is preferable since we avoid any unhandled exceptions accidentally slipping through to the top-level application logic. 
This also makes it possible to reason about the types and data flow of the application and makes it clear where information is passed to/from in the validation logic.

This is accomplished using the `fp-ts` library and its `Either` Monad. 
