### PR TITLE
Prefer commenting on PRs to submitting reviews

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -272,7 +272,7 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
     result: 'failure' | 'success',
   ) => {
     log.debug('Creating review comment on PR #%d.', pullRequestNumber)
-    const invalidBody = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}/checks?check_run_id=${checkId})`
+    const invalidBody = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}/checks?check_run_id=${checkId}).`
     const validBody = '🤖 Well done! The configuration is valid.'
     const wasSuccessful = result === 'success'
     const {

--- a/src/git.ts
+++ b/src/git.ts
@@ -265,49 +265,32 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
     return createOrUpdatePullRequest(repository, prDetails, repository.defaultBranch)
   }
 
-  const requestPullRequestChanges = async (
+  const commentOnPullRequest = async (
     repository: RepositoryDetails,
     pullRequestNumber: number,
     checkId: number,
+    result: 'failure' | 'success',
   ) => {
-    const body = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}/checks?check_run_id=${checkId})`
-
-    log.debug('Creating change request review on PR #%d.', pullRequestNumber)
+    log.debug('Creating review comment on PR #%d.', pullRequestNumber)
+    const invalidBody = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${repository.owner}/${repository.repo}/pull/${pullRequestNumber}/checks?check_run_id=${checkId})`
+    const validBody = '🤖 Well done! The configuration is valid.'
+    const wasSuccessful = result === 'success'
     const {
       data: { id },
-    } = await octokit.pulls.createReview({
+    } = await octokit.pulls.createReviewComment({
       ...repository,
       pull_number: pullRequestNumber,
-      event: 'REQUEST_CHANGES',
-      body,
+      body: wasSuccessful ? validBody : invalidBody,
     })
 
-    log.debug("Created change request review '%d'.", id)
-
-    return id
-  }
-
-  const approvePullRequestChanges = async (repository: RepositoryDetails, pullRequestNumber: number) => {
-    const body = '🤖 Well done!'
-    log.debug('Creating approved review on PR #%d.', pullRequestNumber)
-    const {
-      data: { id },
-    } = await octokit.pulls.createReview({
-      ...repository,
-      pull_number: pullRequestNumber,
-      event: 'APPROVE',
-      body,
-    })
-    log.debug("Created approved review '%d'.", id)
-
+    log.debug("Created review comment '%d'.", id)
     return id
   }
 
   return {
-    approvePullRequestChanges,
     commitFilesToPR,
     getCommitFiles,
     getFilesChanged,
-    requestPullRequestChanges,
+    commentOnPullRequest,
   }
 }

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -95,7 +95,7 @@ describe('Pull Request reviews', () => {
 
     test('can create failure comments on on PRs', async () => {
       const checkId = 123
-      const expectedMainBody = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${testRepository.owner}/${testRepository.repo}/pull/${testPullRequestNumber}/checks?check_run_id=${checkId})`
+      const expectedMainBody = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${testRepository.owner}/${testRepository.repo}/pull/${testPullRequestNumber}/checks?check_run_id=${checkId}).`
 
       const result = await commentOnPullRequest(testRepository, testPullRequestNumber, checkId, 'failure')
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -6,7 +6,7 @@ describe('Pull Request reviews', () => {
   const log = { info: () => ({}), error: () => ({}), debug: () => ({}) } as unknown as Logger
   const octokitMock = {
     pulls: {
-      createReview: jest.fn(() => {
+      createReviewComment: jest.fn(() => {
         return {
           data: {
             id: 'reviewId',
@@ -81,43 +81,43 @@ describe('Pull Request reviews', () => {
   const testRepository = {
     owner: 'pleo',
     repo: 'workflows',
+    defaultBranch: 'main',
   }
 
   const testPullRequestNumber = 1
 
-  const { approvePullRequestChanges, requestPullRequestChanges, commitFilesToPR } = git(log, octokitMock)
+  const { commentOnPullRequest, commitFilesToPR } = git(log, octokitMock)
 
   describe('Create reviews', () => {
     beforeEach(() => {
       jest.clearAllMocks()
     })
 
-    test('can request changes on PRs', async () => {
+    test('can create failure comments on on PRs', async () => {
       const checkId = 123
       const expectedMainBody = `🤖 It looks like your template changes are invalid.\nYou can see the error report [here](https://github.com/${testRepository.owner}/${testRepository.repo}/pull/${testPullRequestNumber}/checks?check_run_id=${checkId})`
 
-      const result = await requestPullRequestChanges(testRepository, testPullRequestNumber, checkId)
+      const result = await commentOnPullRequest(testRepository, testPullRequestNumber, checkId, 'failure')
 
-      expect(octokitMock.pulls.createReview).toBeCalledTimes(1)
-      expect(octokitMock.pulls.createReview).toHaveBeenCalledWith({
+      expect(octokitMock.pulls.createReviewComment).toBeCalledTimes(1)
+      expect(octokitMock.pulls.createReviewComment).toHaveBeenCalledWith({
         ...testRepository,
         pull_number: testPullRequestNumber,
-        event: 'REQUEST_CHANGES',
         body: expectedMainBody,
       })
 
       expect(result).toEqual('reviewId')
     })
 
-    test('can approve PRs', async () => {
-      const expectedBody = '🤖 Well done!'
-      const result = await approvePullRequestChanges(testRepository, testPullRequestNumber)
+    test('can create success comments on PRs', async () => {
+      const checkId = 123
+      const expectedBody = '🤖 Well done! The configuration is valid.'
+      const result = await commentOnPullRequest(testRepository, testPullRequestNumber, checkId, 'success')
 
-      expect(octokitMock.pulls.createReview).toBeCalledTimes(1)
-      expect(octokitMock.pulls.createReview).toHaveBeenCalledWith({
+      expect(octokitMock.pulls.createReviewComment).toBeCalledTimes(1)
+      expect(octokitMock.pulls.createReviewComment).toHaveBeenCalledWith({
         ...testRepository,
         pull_number: testPullRequestNumber,
-        event: 'APPROVE',
         body: expectedBody,
       })
       expect(result).toEqual('reviewId')


### PR DESCRIPTION
This will: 
- Prefer review comment creation to creating actual PR reviews
- Forward the success statuses of the validation to determine which comment to submit
