### PR TITLE
Fix invalid GitHub endpoint for PR review commenting

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -277,9 +277,10 @@ export const git = (log: Logger, octokit: Pick<OctokitInstance, 'pulls' | 'repos
     const wasSuccessful = result === 'success'
     const {
       data: { id },
-    } = await octokit.pulls.createReviewComment({
+    } = await octokit.pulls.createReview({
       ...repository,
       pull_number: pullRequestNumber,
+      event: 'COMMENT',
       body: wasSuccessful ? validBody : invalidBody,
     })
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -6,7 +6,7 @@ describe('Pull Request reviews', () => {
   const log = { info: () => ({}), error: () => ({}), debug: () => ({}) } as unknown as Logger
   const octokitMock = {
     pulls: {
-      createReviewComment: jest.fn(() => {
+      createReview: jest.fn(() => {
         return {
           data: {
             id: 'reviewId',
@@ -99,10 +99,11 @@ describe('Pull Request reviews', () => {
 
       const result = await commentOnPullRequest(testRepository, testPullRequestNumber, checkId, 'failure')
 
-      expect(octokitMock.pulls.createReviewComment).toBeCalledTimes(1)
-      expect(octokitMock.pulls.createReviewComment).toHaveBeenCalledWith({
+      expect(octokitMock.pulls.createReview).toBeCalledTimes(1)
+      expect(octokitMock.pulls.createReview).toHaveBeenCalledWith({
         ...testRepository,
         pull_number: testPullRequestNumber,
+        event: 'COMMENT',
         body: expectedMainBody,
       })
 
@@ -114,10 +115,11 @@ describe('Pull Request reviews', () => {
       const expectedBody = '🤖 Well done! The configuration is valid.'
       const result = await commentOnPullRequest(testRepository, testPullRequestNumber, checkId, 'success')
 
-      expect(octokitMock.pulls.createReviewComment).toBeCalledTimes(1)
-      expect(octokitMock.pulls.createReviewComment).toHaveBeenCalledWith({
+      expect(octokitMock.pulls.createReview).toBeCalledTimes(1)
+      expect(octokitMock.pulls.createReview).toHaveBeenCalledWith({
         ...testRepository,
         pull_number: testPullRequestNumber,
+        event: 'COMMENT',
         body: expectedBody,
       })
       expect(result).toEqual('reviewId')


### PR DESCRIPTION
`createReviewComment` is not the expected endpoint for commenting on PRs - that'd (surprisingly) be `createReview` with `{... event: 'COMMENT'}` - good times.. 

This fixes #85 .