### PR TITLE
Use check outcome for logging

### DIFF
--- a/src/validation.ts
+++ b/src/validation.ts
@@ -102,7 +102,7 @@ export const validation = (
       await updateCheck(failure)
     }
 
-    log.info(`Validated configuration changes in #%d with conclusion: %s.`, prNumber, checkConclusion)
+    log.info(`Validated configuration changes in #%d with conclusion: %s.`, prNumber, checkConclusion.conclusion)
   }
 
   return {


### PR DESCRIPTION
This fixes an `[Object object]` being logged after check creation/update in the logs and will instead use the `conclusion` property for useful logging.